### PR TITLE
Show Codex usage only while active

### DIFF
--- a/basic.py
+++ b/basic.py
@@ -317,11 +317,22 @@ class DisplayManager:
     def _scheduled_mode(self, current_time):
         if not self.token_usage_client.enabled:
             return "auto"
-        return self.display_schedule.mode_at(current_time)
+        scheduled_mode = self.display_schedule.mode_at(current_time)
+        if scheduled_mode != "token":
+            return scheduled_mode
+        snapshot = self.token_usage_client.get_snapshot()
+        if snapshot and snapshot.active and not snapshot.stale:
+            return "token"
+        return self._token_fallback_mode()
+
+    @staticmethod
+    def _token_fallback_mode():
+        mode = os.getenv("token_usage_fallback_mode", "transit").strip().lower()
+        return mode if mode in {"auto", "transit", "weather"} else "transit"
 
     def _draw_token_usage(self, current_time):
         snapshot = self.token_usage_client.get_snapshot()
-        if not snapshot:
+        if not snapshot or not snapshot.active or snapshot.stale:
             return False
         view = token_view_at(current_time, self.token_views)
         set_base_image = self.current_display_mode != "token" or self.current_token_view != view
@@ -513,7 +524,7 @@ class DisplayManager:
                     self.last_display_update = current_time
                     return
                 if scheduled_mode == "token":
-                    scheduled_mode = os.getenv("token_usage_fallback_mode", "transit").strip().lower()
+                    scheduled_mode = self._token_fallback_mode()
                 bus_data, error_message, stop_name = self.bus_manager.get_bus_data()
                 weather_data = self.weather_manager.get_weather_data() if weather_enabled else None
                 
@@ -658,9 +669,7 @@ class DisplayManager:
                                 logger.info("Token usage display updated successfully")
                                 scheduled_mode = "rendered"
                             else:
-                                scheduled_mode = os.getenv(
-                                    "token_usage_fallback_mode", "transit"
-                                ).strip().lower()
+                                scheduled_mode = self._token_fallback_mode()
                         # Check if we have any bus data at all
                         if scheduled_mode == "rendered":
                             pass

--- a/docs/token-usage-display.md
+++ b/docs/token-usage-display.md
@@ -24,8 +24,10 @@ token_usage_fallback_mode=transit
 ```
 
 Supported modes are `auto`, `transit`, `weather`, and `token`. When token data
-is unavailable, `token_usage_fallback_mode` is used. The last good response is
-cached for `token_usage_max_stale_seconds`; stale views are visibly marked.
+is unavailable or does not explicitly report `active: true`,
+`token_usage_fallback_mode` is used. The last good response is cached for
+`token_usage_max_stale_seconds`, but cached activity is never trusted: Codex
+views disappear when the live source is unavailable.
 
 ## Data sources
 
@@ -49,6 +51,13 @@ TOKEN_USAGE_SERVER_TOKEN_FILE=~/.config/token-display/token \
   python tools/token_usage_server.py --host 0.0.0.0 --port 8765
 ```
 
+By default the example bridge reports Codex as active when a `.json` or
+`.jsonl` file below `$CODEX_HOME/sessions` (or `~/.codex/sessions`) was modified
+in the last five minutes. Use `--activity-path` (repeatable) for another session
+location and `--activity-window-seconds` to change the window. Activity is
+rechecked on every request even while the more expensive usage totals are
+cached.
+
 Listening beyond loopback is refused unless a bearer token is configured. The
 bridge returns only the display fields below; account email, account ID, OAuth
 tokens, session names, and project paths are not exposed.
@@ -59,6 +68,7 @@ tokens, session names, and project paths are not exposed.
 {
   "schema_version": 1,
   "generated_at": "2026-01-15T12:00:00+01:00",
+  "active": true,
   "currency": "USD",
   "limits": {
     "primary": {"used_percent": 25, "resets_at": "2026-01-15T16:00:00Z"},

--- a/tests/test_token_usage.py
+++ b/tests/test_token_usage.py
@@ -1,5 +1,6 @@
 import json
 from datetime import datetime
+from types import SimpleNamespace
 
 import pytest
 
@@ -13,6 +14,7 @@ from token_usage import (
 
 SAMPLE = {
     "generated_at": "2026-07-10T12:00:00+02:00",
+    "active": True,
     "currency": "USD",
     "limits": {
         "primary": {"used_percent": 18, "resets_at": "2026-07-10T15:00:00Z"},
@@ -43,9 +45,40 @@ def test_invalid_schedule_is_rejected():
 
 def test_snapshot_reports_remaining_capacity():
     snapshot = TokenUsageSnapshot.from_dict(SAMPLE)
+    assert snapshot.active is True
     assert snapshot.primary.remaining_percent == 82
     assert snapshot.secondary.remaining_percent == 55
     assert snapshot.month_cost_usd == 123.5
+
+
+def test_snapshot_without_explicit_activity_is_inactive():
+    payload = {key: value for key, value in SAMPLE.items() if key != "active"}
+    assert TokenUsageSnapshot.from_dict(payload).active is False
+
+
+def test_scheduled_token_mode_requires_live_activity(monkeypatch):
+    from basic import DisplayManager
+
+    manager = DisplayManager.__new__(DisplayManager)
+    manager.display_schedule = DisplaySchedule("token@00:00-00:00")
+    manager.token_usage_client = SimpleNamespace(
+        enabled=True,
+        get_snapshot=lambda: SimpleNamespace(active=False, stale=False),
+    )
+    monkeypatch.setenv("token_usage_fallback_mode", "weather")
+    now = datetime(2026, 7, 10, 12, 0)
+
+    assert manager._scheduled_mode(now) == "weather"
+    manager.token_usage_client.get_snapshot = lambda: SimpleNamespace(
+        active=True, stale=False
+    )
+    assert manager._scheduled_mode(now) == "token"
+    manager.token_usage_client.get_snapshot = lambda: SimpleNamespace(
+        active=True, stale=True
+    )
+    assert manager._scheduled_mode(now) == "weather"
+    monkeypatch.setenv("token_usage_fallback_mode", "token")
+    assert manager._scheduled_mode(now) == "transit"
 
 
 def test_file_client_reads_and_caches_snapshot(tmp_path, monkeypatch):
@@ -75,6 +108,23 @@ def test_client_discards_cache_after_maximum_stale_age(tmp_path, monkeypatch):
     assert client.get_snapshot() is not None
     source.unlink()
     assert client.get_snapshot(force=True) is None
+
+
+def test_client_does_not_trust_stale_active_status(tmp_path, monkeypatch):
+    source = tmp_path / "snapshot.json"
+    cache = tmp_path / "cache.json"
+    source.write_text(json.dumps(SAMPLE), encoding="utf-8")
+    monkeypatch.setenv("token_usage_enabled", "true")
+    monkeypatch.setenv("token_usage_source", "file")
+    monkeypatch.setenv("token_usage_file", str(source))
+    monkeypatch.setenv("token_usage_cache_file", str(cache))
+    client = TokenUsageClient()
+    assert client.get_snapshot().active is True
+    source.unlink()
+    stale = client.get_snapshot(force=True)
+    assert stale is not None
+    assert stale.stale is True
+    assert stale.active is False
 
 
 def test_view_rotation_uses_configured_duration(monkeypatch):

--- a/tests/test_token_usage_server.py
+++ b/tests/test_token_usage_server.py
@@ -1,7 +1,9 @@
-from tools.token_usage_server import SnapshotBuilder
+import os
+
+from tools.token_usage_server import RecentJsonActivity, SnapshotBuilder
 
 
-def test_bridge_normalizes_and_removes_identity_fields(monkeypatch):
+def test_bridge_normalizes_and_removes_identity_fields(monkeypatch, tmp_path):
     usage = [
         {
             "provider": "codex",
@@ -25,7 +27,11 @@ def test_bridge_normalizes_and_removes_identity_fields(monkeypatch):
             ],
         }
     ]
-    builder = SnapshotBuilder("codexbar", 300)
+    activity_file = tmp_path / "session.jsonl"
+    activity_file.write_text("{}\n", encoding="utf-8")
+    builder = SnapshotBuilder(
+        "codexbar", 300, RecentJsonActivity([tmp_path], 300)
+    )
 
     def fake_run(*arguments):
         return usage if arguments[0] == "usage" else cost
@@ -36,8 +42,46 @@ def test_bridge_normalizes_and_removes_identity_fields(monkeypatch):
     serialized = str(snapshot).lower()
     assert snapshot["limits"]["primary"]["used_percent"] == 25
     assert snapshot["month_to_date"]["cost_usd"] == 12.5
+    assert snapshot["active"] is True
     assert "email" not in serialized
     assert "project" not in serialized
+
+
+def test_recent_json_activity_uses_modification_window(tmp_path):
+    session = tmp_path / "sessions" / "session.jsonl"
+    session.parent.mkdir()
+    session.write_text("{}\n", encoding="utf-8")
+    detector = RecentJsonActivity([session.parent], 300)
+
+    os.utime(session, (699, 699))
+    assert detector.is_active(now=1000) is False
+    os.utime(session, (700, 700))
+    assert detector.is_active(now=1000) is True
+
+
+def test_activity_is_rechecked_while_usage_metrics_are_cached(monkeypatch):
+    class ActivityDetector:
+        def __init__(self):
+            self.active = True
+
+        def is_active(self):
+            return self.active
+
+    detector = ActivityDetector()
+    builder = SnapshotBuilder("codexbar", 300, detector)
+    monkeypatch.setattr(
+        builder,
+        "_run",
+        lambda *arguments: (
+            [{"usage": {}}]
+            if arguments[0] == "usage"
+            else [{"currencyCode": "USD", "daily": []}]
+        ),
+    )
+
+    assert builder.build()["active"] is True
+    detector.active = False
+    assert builder.build()["active"] is False
 
 
 class _JulyDatetime:

--- a/token_usage.py
+++ b/token_usage.py
@@ -94,6 +94,7 @@ class TokenUsageSnapshot:
     daily: List[DailyUsage]
     month_cost_usd: float
     month_tokens: int
+    active: bool = False
     currency: str = "USD"
     stale: bool = False
 
@@ -127,6 +128,9 @@ class TokenUsageSnapshot:
             month_tokens=int(
                 month.get("total_tokens", sum(day.total_tokens for day in daily))
             ),
+            # Missing activity information fails closed: token views are only
+            # eligible when the source explicitly reports current activity.
+            active=payload.get("active") is True,
             currency=str(payload.get("currency") or "USD"),
         )
 
@@ -187,6 +191,9 @@ class TokenUsageClient:
                 return None
             payload = json.loads(self.cache_file.read_text(encoding="utf-8"))
             snapshot = TokenUsageSnapshot.from_dict(payload)
+            # A cached response can preserve usage totals, but it cannot prove
+            # that Codex is still active while the source is unavailable.
+            snapshot.active = False
             snapshot.stale = True
             return snapshot
         except (OSError, ValueError, TypeError, json.JSONDecodeError):

--- a/tools/token_usage_server.py
+++ b/tools/token_usage_server.py
@@ -14,13 +14,55 @@ from datetime import datetime
 from http import HTTPStatus
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any, Dict, Iterable
+
+
+class RecentJsonActivity:
+    """Report activity when a JSON session file was recently modified."""
+
+    def __init__(self, paths: Iterable[Path], window_seconds: int):
+        self.paths = [path.expanduser() for path in paths]
+        self.window_seconds = max(0, window_seconds)
+
+    @staticmethod
+    def _json_files(path: Path):
+        if path.is_file():
+            if path.suffix.lower() in {".json", ".jsonl"}:
+                yield path
+            return
+        if path.is_dir():
+            for candidate in path.rglob("*"):
+                if (
+                    candidate.is_file()
+                    and candidate.suffix.lower() in {".json", ".jsonl"}
+                ):
+                    yield candidate
+
+    def is_active(self, now: float | None = None) -> bool:
+        cutoff = (time.time() if now is None else now) - self.window_seconds
+        for path in self.paths:
+            try:
+                for candidate in self._json_files(path):
+                    try:
+                        if candidate.stat().st_mtime >= cutoff:
+                            return True
+                    except OSError:
+                        continue
+            except OSError:
+                continue
+        return False
 
 
 class SnapshotBuilder:
-    def __init__(self, command: str, cache_seconds: int):
+    def __init__(
+        self,
+        command: str,
+        cache_seconds: int,
+        activity_detector: RecentJsonActivity,
+    ):
         self.command = command
         self.cache_seconds = cache_seconds
+        self.activity_detector = activity_detector
         self._lock = threading.Lock()
         self._cached: Dict[str, Any] | None = None
         self._cached_at = 0.0
@@ -38,7 +80,7 @@ class SnapshotBuilder:
     def build(self) -> Dict[str, Any]:
         with self._lock:
             if self._cached and time.monotonic() - self._cached_at < self.cache_seconds:
-                return self._cached
+                return {**self._cached, "active": self.activity_detector.is_active()}
             usage_rows = self._run(
                 "usage", "--provider", "codex", "--source", "oauth", "--format", "json"
             )
@@ -78,7 +120,9 @@ class SnapshotBuilder:
                 "daily": daily,
             }
             self._cached_at = time.monotonic()
-            return self._cached
+            # Activity is intentionally evaluated separately from the cached
+            # usage metrics so it can turn off promptly between CLI refreshes.
+            return {**self._cached, "active": self.activity_detector.is_active()}
 
 
 def token_from_environment() -> str:
@@ -130,11 +174,36 @@ def main():
     parser.add_argument("--port", type=int, default=8765)
     parser.add_argument("--cache-seconds", type=int, default=300)
     parser.add_argument("--codexbar-command", default="codexbar")
+    parser.add_argument(
+        "--activity-path",
+        action="append",
+        help=(
+            "file or directory containing Codex JSON session data; may be "
+            "repeated (default: $CODEX_HOME/sessions or ~/.codex/sessions)"
+        ),
+    )
+    parser.add_argument(
+        "--activity-window-seconds",
+        type=int,
+        default=300,
+        help="report Codex active after a JSON file changed in this window",
+    )
     args = parser.parse_args()
     token = token_from_environment()
     if args.host not in {"127.0.0.1", "localhost", "::1"} and not token:
         parser.error("a token is required when listening beyond loopback")
-    builder = SnapshotBuilder(args.codexbar_command, max(0, args.cache_seconds))
+    default_codex_home = Path(os.getenv("CODEX_HOME", "~/.codex")).expanduser()
+    activity_paths = [
+        Path(path) for path in (args.activity_path or [default_codex_home / "sessions"])
+    ]
+    activity_detector = RecentJsonActivity(
+        activity_paths, max(0, args.activity_window_seconds)
+    )
+    builder = SnapshotBuilder(
+        args.codexbar_command,
+        max(0, args.cache_seconds),
+        activity_detector,
+    )
     server = ThreadingHTTPServer((args.host, args.port), make_handler(builder, token))
 
     def refresh_loop():

--- a/tools/token_usage_server.py
+++ b/tools/token_usage_server.py
@@ -31,12 +31,12 @@ class RecentJsonActivity:
                 yield path
             return
         if path.is_dir():
-            for candidate in path.rglob("*"):
-                if (
-                    candidate.is_file()
-                    and candidate.suffix.lower() in {".json", ".jsonl"}
-                ):
-                    yield candidate
+            for pattern in ("*.json", "*.jsonl"):
+                yield from (
+                    candidate
+                    for candidate in path.rglob(pattern)
+                    if candidate.is_file()
+                )
 
     def is_active(self, now: float | None = None) -> bool:
         cutoff = (time.time() if now is None else now) - self.window_seconds


### PR DESCRIPTION
## What changed

- require token snapshots to explicitly report `active: true` before the Codex display is eligible
- fall back to transit, weather, or automatic selection when Codex is inactive or the usage response is stale
- update the example usage server to detect recent `.json`/`.jsonl` session activity under `$CODEX_HOME/sessions` using a configurable five-minute window
- re-evaluate activity on every request even when usage totals are cached
- document the additive snapshot field and activity-path CLI options

## Why

The Codex dashboard previously occupied its full scheduled window even when Codex was idle. This aligns it with the display's other activity-driven modes while keeping the schedule as the eligibility window.

## Validation

- `13 passed` in the token usage, server, and display test subset
- targeted Flake8 passed with the repository's Black-compatible `W503` convention ignored
- Python compilation and `git diff --check` passed
- full suite reached 153 passing tests; existing unrelated astronomy/network, weather, dithering, and display assertions still fail on this checkout

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Token usage displays now reflect whether live activity is detected.
  * Added configurable activity detection for recent session file changes.
  * Token usage snapshots now report an explicit active/inactive status.
  * Added configurable fallback display modes when live token activity is unavailable.

* **Bug Fixes**
  * Stale cached data no longer appears as active.
  * Scheduled token displays now fall back reliably when data is missing, inactive, or outdated.
  * Activity status is refreshed even when usage totals are served from cache.

* **Documentation**
  * Clarified token display fallback behavior and activity detection details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->