### PR TITLE
Fix and modernize test suite

### DIFF
--- a/color_utils.py
+++ b/color_utils.py
@@ -1,6 +1,3 @@
-from functools import lru_cache
-
-
 def _find_optimal_colors(pixel_rgb, epd):
     """Find optimal combination of available colors to represent an RGB value"""
     r, g, b = pixel_rgb[:3]
@@ -118,7 +115,6 @@ def _find_optimal_colors(pixel_rgb, epd):
     return [('black', 0.6), ('white', 0.4)]
 
 
-@lru_cache(maxsize=1024)
 def find_optimal_colors(pixel_rgb, epd):
     """Return a normalized display-color mix for an RGB value."""
     colors_with_ratios = _find_optimal_colors(pixel_rgb, epd)

--- a/color_utils.py
+++ b/color_utils.py
@@ -1,8 +1,7 @@
 from functools import lru_cache
 
 
-@lru_cache(maxsize=1024)
-def find_optimal_colors(pixel_rgb, epd):
+def _find_optimal_colors(pixel_rgb, epd):
     """Find optimal combination of available colors to represent an RGB value"""
     r, g, b = pixel_rgb[:3]
 
@@ -117,3 +116,18 @@ def find_optimal_colors(pixel_rgb, epd):
 
     # Default fallback
     return [('black', 0.6), ('white', 0.4)]
+
+
+@lru_cache(maxsize=1024)
+def find_optimal_colors(pixel_rgb, epd):
+    """Return a normalized display-color mix for an RGB value."""
+    colors_with_ratios = _find_optimal_colors(pixel_rgb, epd)
+    total_ratio = sum(ratio for _, ratio in colors_with_ratios)
+
+    if total_ratio <= 0:
+        return [('black', 1.0)]
+
+    return [
+        (color, ratio / total_ratio)
+        for color, ratio in colors_with_ratios
+    ]

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+pythonpath = .
+testpaths = tests

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,5 @@
+import atexit
+import shutil
 import pytest
 from pathlib import Path
 import os
@@ -6,6 +8,7 @@ import tempfile
 # Keep imports such as log_config and dotenv away from a developer's real home.
 TEST_HOME = Path(tempfile.mkdtemp(prefix="rpi-waiting-time-display-tests-"))
 os.environ["HOME"] = str(TEST_HOME)
+atexit.register(shutil.rmtree, TEST_HOME, ignore_errors=True)
 
 @pytest.fixture
 def mock_env_vars():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,44 +1,11 @@
 import pytest
 from pathlib import Path
 import os
-import shutil
-import logging
-from datetime import datetime, timedelta
+import tempfile
 
-logger = logging.getLogger(__name__)
-
-@pytest.fixture(scope="session", autouse=True)
-def manage_env_files():
-    """Backup real .env files and replace with test versions, restore after tests"""
-    display_dir = Path.home() / 'display_programme'
-    transit_dir = Path.home() / 'brussels_transit'
-    env_files = [
-        (display_dir / '.env', display_dir / '.env.test'),
-        (transit_dir / '.env', transit_dir / '.env.test'),
-        (transit_dir / 'app' / 'config' / 'local.py', transit_dir / 'app' / 'config' / 'local.py.test')
-    ]
-
-    # Backup existing files and replace with test versions
-    backups = []
-    for real_file, test_file in env_files:
-        if real_file.exists():
-            backup_file = real_file.with_suffix('.backup')
-            shutil.copy2(real_file, backup_file)
-            backups.append((real_file, backup_file))
-            logger.debug(f"Backed up {real_file} to {backup_file}")
-
-        if test_file.exists():
-            shutil.copy2(test_file, real_file)
-            logger.debug(f"Replaced {real_file} with test version from {test_file}")
-
-    yield  # Run the tests
-
-    # Restore original files
-    for real_file, backup_file in backups:
-        if backup_file.exists():
-            shutil.copy2(backup_file, real_file)
-            backup_file.unlink()
-            logger.debug(f"Restored {real_file} from {backup_file}")
+# Keep imports such as log_config and dotenv away from a developer's real home.
+TEST_HOME = Path(tempfile.mkdtemp(prefix="rpi-waiting-time-display-tests-"))
+os.environ["HOME"] = str(TEST_HOME)
 
 @pytest.fixture
 def mock_env_vars():
@@ -46,8 +13,8 @@ def mock_env_vars():
     return {
         'BUS_API_BASE_URL': 'http://127.0.0.1:5001/',
         'Provider': 'test_provider',
-        'Stop_ID': '2100',  # This is our test stop ID
-        'Lines': '0090',
+        'Stops': '2100',
+        'Lines': '64',
         'City': 'Test City',
         'Country': 'Test Country',
         'Coordinates_LAT': '51.5085',
@@ -68,4 +35,4 @@ def sample_bus_response():
             }
         },
         'name': 'Test Stop'
-    } 
+    }

--- a/tests/test_astronomy.py
+++ b/tests/test_astronomy.py
@@ -1,95 +1,163 @@
-import pytest
-from datetime import datetime, timezone
-from astronomy_utils import get_moon_phase, get_daily_moon_change, get_upcoming_moon_phases
-from freezegun import freeze_time
+import math
+from datetime import datetime, timedelta, timezone
 
-@pytest.fixture
-def fixed_datetime():
-    """Fixture providing a fixed datetime for consistent testing"""
-    return datetime(2023, 12, 23, 12, 0, tzinfo=timezone.utc)
+import pytest
+
+import astronomy_utils
+
+
+class FakeAngle:
+    def __init__(self, degrees):
+        self.degrees = degrees
+
+
+class FakeTime:
+    def __init__(self, value):
+        self.value = value
+
+    def utc_datetime(self):
+        return self.value
+
+
+class FakeTimescale:
+    def now(self):
+        return FakeTime(datetime(2023, 12, 23, 12, tzinfo=timezone.utc))
+
+    def from_datetime(self, value):
+        return FakeTime(value)
+
+
+class FakeApparent:
+    def __init__(self, body, time):
+        self.body = body
+        self.time = time
+
+    @property
+    def phase_angle(self):
+        start = datetime(2023, 12, 23, 12, tzinfo=timezone.utc)
+        elapsed_days = (self.time.value - start).total_seconds() / 86400
+        return (135.0 + 12.2 * elapsed_days) % 360
+
+    def apparent(self):
+        return self
+
+    def frame_latlon(self, _frame):
+        angle = self.phase_angle if self.body == "moon" else 0.0
+        return None, FakeAngle(angle), None
+
+    def fraction_illuminated(self, _sun):
+        return (1 - math.cos(math.radians(self.phase_angle))) / 2
+
+
+class FakeObserver:
+    def __init__(self, time):
+        self.time = time
+
+    def observe(self, body):
+        return FakeApparent(body, self.time)
+
+
+class FakeEarth:
+    def at(self, time):
+        return FakeObserver(time)
+
+
+class FakeEphemeris(dict):
+    def __init__(self):
+        super().__init__(sun="sun", moon="moon", earth=FakeEarth())
+
+
+class FakeLoad:
+    def __init__(self):
+        self.calls = []
+
+    def timescale(self):
+        return FakeTimescale()
+
+    def __call__(self, filename):
+        self.calls.append(filename)
+        return FakeEphemeris()
+
+
+@pytest.fixture(autouse=True)
+def fake_ephemeris(monkeypatch):
+    fake_load = FakeLoad()
+    cached_get_moon_phase = astronomy_utils.get_moon_phase
+    cached_get_moon_phase.cache_clear()
+    monkeypatch.setattr(astronomy_utils, "load", fake_load)
+    yield fake_load
+    cached_get_moon_phase.cache_clear()
+
 
 def test_get_moon_phase_structure():
-    """Test the structure of moon phase data"""
-    phase_data = get_moon_phase()
-    
-    assert isinstance(phase_data, dict)
-    assert 'phase_angle' in phase_data
-    assert 'emoji' in phase_data
-    assert 'name' in phase_data
-    assert 'percent_illuminated' in phase_data
-    
-    assert isinstance(phase_data['phase_angle'], float)
-    assert isinstance(phase_data['emoji'], str)
-    assert isinstance(phase_data['name'], str)
-    assert isinstance(phase_data['percent_illuminated'], float)
-    
-    assert 0 <= phase_data['phase_angle'] <= 360
-    assert 0 <= phase_data['percent_illuminated'] <= 100
+    phase_data = astronomy_utils.get_moon_phase()
 
-@freeze_time("2023-12-23 12:00:00")
-def test_get_moon_phase_specific_time(fixed_datetime):
-    """Test moon phase calculation for a specific time"""
-    phase_data = get_moon_phase(fixed_datetime)
-    
-    # The values below are specific to 2023-12-23 12:00:00 UTC
-    assert isinstance(phase_data['phase_angle'], float)
-    assert isinstance(phase_data['name'], str)
-    assert phase_data['name'] in [
-        'New Moon', 'Waxing Crescent', 'First Quarter', 
-        'Waxing Gibbous', 'Full Moon', 'Waning Gibbous', 
-        'Last Quarter', 'Waning Crescent'
+    assert set(phase_data) == {
+        "phase_angle",
+        "emoji",
+        "name",
+        "percent_illuminated",
+    }
+    assert isinstance(phase_data["phase_angle"], float)
+    assert isinstance(phase_data["emoji"], str)
+    assert isinstance(phase_data["name"], str)
+    assert isinstance(phase_data["percent_illuminated"], float)
+    assert 0 <= phase_data["phase_angle"] <= 360
+    assert 0 <= phase_data["percent_illuminated"] <= 100
+
+
+def test_get_moon_phase_specific_time():
+    timestamp = datetime(2023, 12, 23, 12, tzinfo=timezone.utc)
+    phase_data = astronomy_utils.get_moon_phase(timestamp)
+
+    assert phase_data["phase_angle"] == pytest.approx(135.0)
+    assert phase_data["name"] == "Waxing Gibbous"
+
+
+def test_get_daily_moon_change(monkeypatch):
+    phases = iter(
+        [
+            {"percent_illuminated": 40.0},
+            {"percent_illuminated": 51.0},
+        ]
+    )
+    monkeypatch.setattr(astronomy_utils, "get_moon_phase", lambda _time: next(phases))
+
+    assert astronomy_utils.get_daily_moon_change() == {
+        "current": 40.0,
+        "tomorrow": 51.0,
+        "change": 11.0,
+    }
+
+
+def test_get_upcoming_moon_phases(monkeypatch):
+    phase_time = datetime(2023, 12, 27, 12, tzinfo=timezone.utc)
+    monkeypatch.setattr(astronomy_utils.almanac, "moon_phases", lambda _eph: object())
+    monkeypatch.setattr(
+        astronomy_utils.almanac,
+        "find_discrete",
+        lambda _start, _end, _function: ([FakeTime(phase_time)], [0]),
+    )
+
+    assert astronomy_utils.get_upcoming_moon_phases(30) == [
+        {"time": phase_time, "phase_name": "New Moon"}
     ]
 
-def test_get_daily_moon_change():
-    """Test daily moon change calculation"""
-    change_data = get_daily_moon_change()
-    
-    assert isinstance(change_data, dict)
-    assert 'current' in change_data
-    assert 'tomorrow' in change_data
-    assert 'change' in change_data
-    
-    assert isinstance(change_data['current'], float)
-    assert isinstance(change_data['tomorrow'], float)
-    assert isinstance(change_data['change'], float)
-    
-    # Moon moves approximately 11.6-12.7 degrees per day
-    # Allow for some variation in the calculation
-    assert 8 <= abs(change_data['change']) <= 15
 
-def test_get_upcoming_moon_phases():
-    """Test upcoming moon phases calculation"""
-    days_ahead = 30
-    phases = get_upcoming_moon_phases(days_ahead)
-    
-    assert isinstance(phases, list)
-    assert len(phases) > 0  # Should have at least one phase in the next 30 days
-    
-    for phase in phases:
-        assert isinstance(phase, dict)
-        assert 'time' in phase
-        assert 'phase_name' in phase
-        assert isinstance(phase['time'], datetime)
-        assert phase['phase_name'] in ['New Moon', 'First Quarter', 'Full Moon', 'Last Quarter']
+def test_moon_phase_cache(fake_ephemeris):
+    timestamp = datetime(2023, 12, 23, 12, tzinfo=timezone.utc)
+    result1 = astronomy_utils.get_moon_phase(timestamp)
+    result2 = astronomy_utils.get_moon_phase(timestamp)
 
-def test_moon_phase_cache():
-    """Test that moon phase caching works"""
-    # Call twice with same timestamp
-    timestamp = datetime(2023, 12, 23, 12, 0, tzinfo=timezone.utc)
-    result1 = get_moon_phase(timestamp)
-    result2 = get_moon_phase(timestamp)
-    
-    # Should return exact same object due to caching
     assert result1 is result2
+    assert fake_ephemeris.calls == ["de421.bsp"]
+
 
 def test_different_timestamps():
-    """Test moon phase calculation for different timestamps"""
-    timestamp1 = datetime(2023, 12, 23, 12, 0, tzinfo=timezone.utc)
-    timestamp2 = datetime(2023, 12, 24, 12, 0, tzinfo=timezone.utc)
-    
-    phase1 = get_moon_phase(timestamp1)
-    phase2 = get_moon_phase(timestamp2)
-    
-    # Should have different values for different days
-    assert phase1['phase_angle'] != phase2['phase_angle']
-    assert abs(phase1['phase_angle'] - phase2['phase_angle']) >= 10  # At least 10 degrees difference in a day
+    timestamp1 = datetime(2023, 12, 23, 12, tzinfo=timezone.utc)
+    timestamp2 = timestamp1 + timedelta(days=1)
+
+    phase1 = astronomy_utils.get_moon_phase(timestamp1)
+    phase2 = astronomy_utils.get_moon_phase(timestamp2)
+
+    assert phase2["phase_angle"] - phase1["phase_angle"] == pytest.approx(12.2)

--- a/tests/test_bus_service.py
+++ b/tests/test_bus_service.py
@@ -1,163 +1,126 @@
-import pytest
-import responses
 from datetime import datetime, timedelta
-import os
-import json
+from unittest.mock import MagicMock, patch
+
+import pytest
 
 from bus_service import BusService, _parse_lines
-from unittest.mock import patch, MagicMock
-import re
+
+
+def make_response(*, status=200, data=None, error=None):
+    response = MagicMock()
+    response.status_code = status
+    response.text = ""
+    response.elapsed.total_seconds.return_value = 0.01
+    response.json.return_value = data
+    response.raise_for_status.side_effect = error
+    return response
+
 
 @pytest.fixture
 def bus_service(mock_env_vars):
-    """Fixture providing a BusService instance"""
-    with patch.dict(os.environ, mock_env_vars, clear=True):
+    with (
+        patch.dict("os.environ", mock_env_vars, clear=True),
+        patch("bus_service.Stop", mock_env_vars["Stops"]),
+        patch("bus_service.Lines", mock_env_vars["Lines"]),
+        patch("bus_service.bus_api_base_url", mock_env_vars["BUS_API_BASE_URL"]),
+        patch("bus_service.bus_schedule_url", mock_env_vars["BUS_API_BASE_URL"]),
+        patch.object(BusService, "_start_health_check"),
+    ):
         return BusService()
 
-@pytest.fixture
-def mock_responses():
-    """Fixture to mock API responses using the responses library"""
-    with responses.RequestsMock(assert_all_requests_are_fired=False) as rsps:
-        yield rsps
 
-@pytest.mark.parametrize("lines_input,expected", [
-    ("64", ["64"]),
-    ("64,59", ["64", "59"]),
-    ("64 59", ["64", "59"]),
-    ("64, 59", ["64", "59"]),
-    ([59, 64], ["59", "64"]),
-    (["59", "64"], ["59", "64"]),
-    ("", []),
-    (None, []),
-])
+@pytest.mark.parametrize(
+    "lines_input,expected",
+    [
+        ("64", ["64"]),
+        ("64,59", ["64", "59"]),
+        ("64 59", ["64", "59"]),
+        ("64, 59", ["64", "59"]),
+        ([59, 64], ["59", "64"]),
+        (["59", "64"], ["59", "64"]),
+        ("", []),
+        (None, []),
+    ],
+)
 def test_parse_lines(lines_input, expected):
-    """Test line number parsing with different input formats"""
     if isinstance(lines_input, (list, tuple)):
         result = [str(x) for x in lines_input]
-        assert sorted(result) == sorted(expected)
     else:
-        with patch.dict(os.environ, {'Lines': str(lines_input) if lines_input is not None else ''}, clear=True):
-            result = _parse_lines(lines_input)
-            assert sorted(result) == sorted(expected)
+        result = _parse_lines(lines_input)
+    assert sorted(result) == sorted(expected)
+
 
 def test_bus_service_initialization(bus_service, mock_env_vars):
-    """Test BusService initialization"""
-    assert bus_service.base_url.rstrip('/').replace('localhost', '127.0.0.1') == mock_env_vars["BUS_API_BASE_URL"].rstrip('/')
+    assert bus_service.base_url == mock_env_vars["BUS_API_BASE_URL"].rstrip("/")
     assert bus_service.provider == mock_env_vars["Provider"]
-    assert bus_service.stop_id == "F00583"
-    assert isinstance(bus_service.lines_of_interest, list)
+    assert bus_service.stop_id == mock_env_vars["Stops"]
+    assert bus_service.lines_of_interest == ["64"]
 
-@responses.activate
-def test_get_waiting_times_success(bus_service, mock_responses, sample_bus_response):
-    """Test successful waiting times retrieval"""
-    # Mock the API health check
-    mock_responses.add(
-        responses.GET,
-        "http://localhost:5001/health",
-        json={"status": "ok"},
-        status=200
-    )
 
-    # Mock the API response
-    mock_responses.add(
-        responses.GET,
-        "http://localhost:5001/api/test_provider/waiting_times/",
-        json={"stops": {bus_service.stop_id: sample_bus_response}},
-        status=200
-    )
+def test_get_waiting_times_success(bus_service, sample_bus_response):
+    response = make_response(data={"stops": {bus_service.stop_id: sample_bus_response}})
 
-    departures, error, stop_name = bus_service.get_waiting_times()
-    
-    assert departures is not None
-    assert len(departures) > 0
+    with patch("bus_service.requests.get", return_value=response) as request:
+        departures, error, stop_name = bus_service.get_waiting_times()
+
+    request.assert_called_once_with(bus_service.api_url, timeout=120)
     assert error is None
     assert stop_name == "Test Stop"
     assert departures[0]["line"] == "64"
     assert departures[0]["times"] == ["5"]
 
-@responses.activate
-def test_get_waiting_times_error(bus_service, mock_responses):
-    """Test waiting times retrieval with API error"""
-    # Mock the API health check
-    mock_responses.add(
-        responses.GET,
-        "http://localhost:5001/health",
-        json={"status": "error"},
-        status=500
-    )
 
-    # First failure
-    departures, error, stop_name = bus_service.get_waiting_times()
-    assert departures is not None  # Should return error data
-    assert error == "API not available"
-    assert stop_name == ""
-    assert bus_service._consecutive_failures == 1
-    assert bus_service._next_retry_time is not None
+def test_get_waiting_times_backoff_and_recovery(bus_service, sample_bus_response):
+    failure = make_response(status=500, error=RuntimeError("API unavailable"))
 
-    # Get initial backoff time
-    first_retry = bus_service._next_retry_time
+    with patch("bus_service.requests.get", return_value=failure) as request:
+        departures, error, stop_name = bus_service.get_waiting_times()
 
-    # Second failure
-    departures, error, stop_name = bus_service.get_waiting_times()
-    assert "Backing off until" in error
-    assert bus_service._consecutive_failures == 1  # Shouldn't increment because we're in backoff
-    assert bus_service._next_retry_time == first_retry  # Should keep same retry time
+        assert departures
+        assert error == "Service error"
+        assert stop_name == ""
+        assert bus_service._fallback_backoff.get_failure_count() == 1
 
-    # Simulate waiting past backoff time
-    bus_service._next_retry_time = datetime.now() - timedelta(seconds=1)
+        first_retry = bus_service._fallback_backoff._next_retry_time
+        _departures, error, _stop_name = bus_service.get_waiting_times()
+        assert "Next attempt at" in error
+        assert request.call_count == 1
 
-    # Third failure
-    departures, error, stop_name = bus_service.get_waiting_times()
-    assert bus_service._consecutive_failures == 2
-    assert bus_service._next_retry_time > first_retry  # Should have a later retry time
+        bus_service._fallback_backoff._next_retry_time = datetime.now() - timedelta(
+            seconds=1
+        )
+        bus_service.get_waiting_times()
+        assert bus_service._fallback_backoff.get_failure_count() == 2
+        assert bus_service._fallback_backoff._next_retry_time > first_retry
 
-    # Test successful response resets backoff
-    mock_responses.replace(
-        responses.GET,
-        "http://localhost:5001/health",
-        json={"status": "ok"},
-        status=200
-    )
-    mock_responses.add(
-        responses.GET,
-        "http://localhost:5001/api/test_provider/waiting_times/",
-        json={"stops": {bus_service.stop_id: {"name": "Test Stop", "lines": {}}}},
-        status=200
-    )
+        success = make_response(
+            data={"stops": {bus_service.stop_id: sample_bus_response}}
+        )
+        request.return_value = success
+        bus_service._fallback_backoff._next_retry_time = datetime.now() - timedelta(
+            seconds=1
+        )
+        bus_service.get_waiting_times()
 
-    # Simulate waiting past backoff time
-    bus_service._next_retry_time = datetime.now() - timedelta(seconds=1)
+    assert bus_service._fallback_backoff.get_failure_count() == 0
+    assert bus_service._fallback_backoff._next_retry_time is None
 
-    # Should reset on success
-    departures, error, stop_name = bus_service.get_waiting_times()
-    assert bus_service._consecutive_failures == 0
-    assert bus_service._next_retry_time is None
 
-def test_get_line_color(bus_service):
-    """Test line color determination"""
-    # Test with a known line number
-    primary_color, secondary_color, ratio = bus_service.get_line_color("64")
-    assert primary_color in ['black', 'white', 'red', 'yellow']
-    assert secondary_color in ['black', 'white', 'red', 'yellow']
-    assert 0 <= ratio <= 1
+def test_get_line_color_without_display(bus_service):
+    colors = bus_service.get_line_color("64")
 
-@responses.activate
-def test_get_api_health(bus_service, mock_responses):
-    """Test API health check"""
-    # Test successful health check
-    mock_responses.add(
-        responses.GET,
-        "http://localhost:5001/health",
-        json={"status": "ok"},
-        status=200
-    )
-    assert bus_service.get_api_health() is True
+    assert colors == [("black", 0.7), ("white", 0.3)]
 
-    # Test failed health check
-    mock_responses.replace(
-        responses.GET,
-        "http://localhost:5001/health",
-        json={"status": "error"},
-        status=500
-    )
-    assert bus_service.get_api_health() is False 
+
+def test_get_api_health(bus_service):
+    with patch(
+        "bus_service.requests.get",
+        return_value=make_response(status=200, data={"status": "ok"}),
+    ):
+        assert bus_service.get_api_health() is True
+
+    with patch(
+        "bus_service.requests.get",
+        return_value=make_response(status=500, data={"status": "error"}),
+    ):
+        assert bus_service.get_api_health() is False

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -1,8 +1,8 @@
 import pytest
 from PIL import Image
 from display_adapter import DisplayAdapter, MockDisplay, return_display_lock
+from threading import Lock
 from unittest.mock import patch
-from _thread import LockType
 import os
 
 @pytest.fixture
@@ -84,7 +84,7 @@ def test_display_lock():
     """Test display lock functionality"""
     lock = return_display_lock()
     assert lock is not None
-    assert isinstance(lock, LockType)
+    assert isinstance(lock, type(Lock()))
     
     # Test that the same lock is returned on subsequent calls
     lock2 = return_display_lock()

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -1,8 +1,8 @@
 import pytest
 from PIL import Image
 from display_adapter import DisplayAdapter, MockDisplay, return_display_lock
-from unittest.mock import patch, MagicMock
-from threading import Lock
+from unittest.mock import patch
+from _thread import LockType
 import os
 
 @pytest.fixture
@@ -84,7 +84,7 @@ def test_display_lock():
     """Test display lock functionality"""
     lock = return_display_lock()
     assert lock is not None
-    assert isinstance(lock, Lock)
+    assert isinstance(lock, LockType)
     
     # Test that the same lock is returned on subsequent calls
     lock2 = return_display_lock()
@@ -104,10 +104,8 @@ def test_getbuffer_wrapper(mock_display):
     test_image = Image.new('RGB', (mock_display.width, mock_display.height), color='white')
     
     # Get buffer
-    buffer = mock_display.getbuffer(test_image)
+    with patch.object(DisplayAdapter, 'save_debug_image') as mock_save:
+        buffer = mock_display.getbuffer(test_image)
     assert buffer is not None
-    
-    # For B&W display, should convert to 1-bit
-    if mock_display.is_bw_display:
-        assert isinstance(buffer, Image.Image)
-        assert buffer.mode in ['1', 'L']
+    assert buffer is test_image
+    mock_save.assert_called_once_with(test_image)

--- a/tests/test_dithering.py
+++ b/tests/test_dithering.py
@@ -225,8 +225,6 @@ def test_color_ratios():
         for _, ratio in colors_with_ratios:
             assert 0 <= ratio <= 1, f"Individual ratio should be between 0 and 1 for {hex_color}"
     
-    return results
-
 if __name__ == "__main__":
     # Save images in a permanent test_output directory
     output_dir = "test_output"
@@ -271,4 +269,4 @@ if __name__ == "__main__":
                 for color, ratio in colors_with_ratios:
                     f.write(f"  {color}: {ratio:.2f}\n")
             
-    print(f"\nTest results have been saved to the '{output_dir}' directory.") 
+    print(f"\nTest results have been saved to the '{output_dir}' directory.")

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -12,8 +12,8 @@ def test_create_openmeteo_provider(monkeypatch):
     
     provider = create_weather_provider('openmeteo')
     assert isinstance(provider, OpenMeteoProvider)
-    assert provider.lat == '50.8505'
-    assert provider.lon == '4.3488'
+    assert provider.lat == 50.8505
+    assert provider.lon == 4.3488
     assert provider.unit == TemperatureUnit.CELSIUS
 
 def test_create_openweather_provider(monkeypatch):
@@ -24,30 +24,31 @@ def test_create_openweather_provider(monkeypatch):
     
     provider = create_weather_provider('openweather')
     assert isinstance(provider, OpenWeatherProvider)
-    assert provider.lat == '50.8505'
-    assert provider.lon == '4.3488'
+    assert provider.lat == 50.8505
+    assert provider.lon == 4.3488
     assert provider.unit == TemperatureUnit.CELSIUS
 
 def test_create_provider_with_explicit_coordinates():
     """Test creating provider with explicit coordinates"""
     provider = create_weather_provider('openmeteo', lat='51.5074', lon='-0.1278')
     assert isinstance(provider, OpenMeteoProvider)
-    assert provider.lat == '51.5074'
-    assert provider.lon == '-0.1278'
+    assert provider.lat == 51.5074
+    assert provider.lon == -0.1278
 
 def test_create_provider_with_unit():
     """Test creating provider with specific temperature unit"""
     provider = create_weather_provider('openmeteo', lat='51.5074', lon='-0.1278', unit='fahrenheit')
     assert provider.unit == TemperatureUnit.FAHRENHEIT
 
-def test_missing_coordinates(monkeypatch):
-    """Test error when coordinates are missing"""
+def test_default_coordinates(monkeypatch):
+    """Test the Brussels defaults when coordinates are missing."""
     # Clear environment variables
     monkeypatch.delenv('Coordinates_LAT', raising=False)
     monkeypatch.delenv('Coordinates_LNG', raising=False)
     
-    with pytest.raises(ValueError, match="Coordinates must be provided"):
-        create_weather_provider('openmeteo')
+    provider = create_weather_provider('openmeteo')
+    assert provider.lat == 50.8503
+    assert provider.lon == 4.3517
 
 def test_missing_api_key(monkeypatch):
     """Test fallback to OpenMeteo when OpenWeather API key is missing"""
@@ -56,10 +57,10 @@ def test_missing_api_key(monkeypatch):
     
     provider = create_weather_provider('openweather', lat='51.5074', lon='-0.1278')
     assert isinstance(provider, OpenMeteoProvider)  # Should fallback to OpenMeteo
-    assert provider.lat == '51.5074'
-    assert provider.lon == '-0.1278'
+    assert provider.lat == 51.5074
+    assert provider.lon == -0.1278
 
 def test_invalid_provider():
     """Test error with invalid provider name"""
     with pytest.raises(ValueError, match="Unknown provider"):
-        create_weather_provider('invalid_provider', lat='51.5074', lon='-0.1278') 
+        create_weather_provider('invalid_provider', lat='51.5074', lon='-0.1278')

--- a/tests/test_openweather.py
+++ b/tests/test_openweather.py
@@ -115,8 +115,8 @@ def test_fetch_weather(provider, sample_weather_response, sample_forecast_respon
     weather_data = provider.get_weather()
     
     # Test current weather
-    assert weather_data.current.temperature == 15
-    assert weather_data.current.feels_like == 15
+    assert weather_data.current.temperature == 15.3
+    assert weather_data.current.feels_like == 14.8
     assert weather_data.current.humidity == 65
     assert weather_data.current.pressure == 1015
     assert weather_data.current.condition.description == "Clear sky"
@@ -161,7 +161,7 @@ def test_error_handling(provider):
     # Cache should be empty
     assert provider._cache is None
 
-def test_icon_mapping():
+def test_icon_mapping(mock_env):
     """Test weather condition to icon mapping"""
     provider = OpenWeatherProvider(lat=50.8505, lon=4.3488)
     
@@ -270,4 +270,4 @@ def test_temperature_units(provider, sample_weather_response, sample_forecast_re
         status=200
     )
     weather_data = provider.get_weather()
-    assert weather_data.current.unit == TemperatureUnit.KELVIN 
+    assert weather_data.current.unit == TemperatureUnit.KELVIN

--- a/tests/test_weather.py
+++ b/tests/test_weather.py
@@ -1,137 +1,111 @@
+from datetime import datetime
+from unittest.mock import MagicMock, patch
+
 import pytest
-import responses
-import os
+
 from weather import WeatherService
-from unittest.mock import patch, MagicMock
+from weather.models import (
+    AirQuality,
+    CurrentWeather,
+    DailyForecast,
+    TemperatureUnit,
+    WeatherCondition,
+    WeatherData,
+)
+
 
 @pytest.fixture
-def weather_service(mock_env_vars):
-    """Fixture providing a WeatherService instance with mocked environment variables"""
-    with patch.dict(os.environ, mock_env_vars, clear=True):
-        with patch('weather.weather_api_key', mock_env_vars['OPENWEATHER_API_KEY']), \
-             patch('weather.coordinates_lat', mock_env_vars['Coordinates_LAT']), \
-             patch('weather.coordinates_lng', mock_env_vars['Coordinates_LNG']), \
-             patch('weather.city', mock_env_vars['City']), \
-             patch('weather.country', mock_env_vars['Country']):
-            service = WeatherService()
-            return service
+def weather_data():
+    condition = WeatherCondition(description="Clear sky", icon="sun")
+    return WeatherData(
+        current=CurrentWeather(
+            temperature=15.3,
+            feels_like=14.8,
+            humidity=65,
+            pressure=1015,
+            condition=condition,
+            unit=TemperatureUnit.CELSIUS,
+        ),
+        air_quality=AirQuality(
+            aqi=1,
+            label="Good",
+            components={"pm2_5": 4.11},
+        ),
+        daily_forecast=[
+            DailyForecast(
+                date=datetime(2024, 1, 2),
+                min_temp=8,
+                max_temp=16,
+                condition=condition,
+            )
+        ],
+        sunrise=datetime(2024, 1, 1, 8, 45),
+        sunset=datetime(2024, 1, 1, 16, 45),
+        is_day=True,
+    )
+
 
 @pytest.fixture
-def mock_responses():
-    """Fixture to mock API responses using the responses library"""
-    with responses.RequestsMock(assert_all_requests_are_fired=False) as rsps:
-        yield rsps
+def weather_service(monkeypatch):
+    monkeypatch.setenv("WEATHER_PROVIDER", "openweather")
+    provider = MagicMock()
+    with patch(
+        "weather.display.create_weather_provider", return_value=provider
+    ) as factory:
+        service = WeatherService()
+    return service, provider, factory
 
-def test_weather_service_initialization(weather_service, mock_env_vars):
-    """Test WeatherService initialization with environment variables"""
-    assert weather_service.api_key == mock_env_vars['OPENWEATHER_API_KEY']
-    assert float(weather_service.lat) == float(mock_env_vars['Coordinates_LAT'])
-    assert float(weather_service.lon) == float(mock_env_vars['Coordinates_LNG'])
-    assert weather_service.city == mock_env_vars['City']
-    assert weather_service.country == mock_env_vars['Country']
 
-@responses.activate
-def test_get_weather_success(weather_service, mock_responses, sample_weather_response, mock_env_vars):
-    """Test successful weather data retrieval"""
-    # Mock the API response with the correct URL pattern
-    mock_responses.add(
-        responses.GET,
-        weather_service.base_url,
-        match=[
-            responses.matchers.query_param_matcher({
-                'lat': str(float(weather_service.lat)),
-                'lon': str(float(weather_service.lon)),
-                'appid': mock_env_vars['OPENWEATHER_API_KEY'],
-                'units': 'metric'
-            })
-        ],
-        json=sample_weather_response,
-        status=200
-    )
+def test_weather_service_initialization(weather_service):
+    service, provider, factory = weather_service
 
-    weather_data = weather_service.get_weather()
-    
-    assert weather_data is not None
-    assert weather_data['temperature'] == round(sample_weather_response['main']['temp'])
-    assert weather_data['description'] == sample_weather_response['weather'][0]['main']
-    assert weather_data['humidity'] == sample_weather_response['main']['humidity']
-    assert 'time' in weather_data
-    assert weather_data['icon'] == sample_weather_response['weather'][0]['icon']
-    assert weather_data['feels_like'] == round(sample_weather_response['main']['feels_like'])
-    assert weather_data['pressure'] == sample_weather_response['main']['pressure']
+    assert service.provider is provider
+    factory.assert_called_once_with("openweather")
 
-@responses.activate
-def test_get_weather_api_error(weather_service, mock_responses, mock_env_vars):
-    """Test weather data retrieval with API error"""
-    # Mock a failed API response with the correct URL pattern
-    mock_responses.add(
-        responses.GET,
-        weather_service.base_url,
-        match=[
-            responses.matchers.query_param_matcher({
-                'lat': str(float(weather_service.lat)),
-                'lon': str(float(weather_service.lon)),
-                'appid': mock_env_vars['OPENWEATHER_API_KEY'],
-                'units': 'metric'
-            })
-        ],
-        json={"message": "API error"},
-        status=401
-    )
 
-    weather_data = weather_service.get_weather()
-    
-    assert weather_data is not None
-    assert weather_data['temperature'] == '--'
-    assert weather_data['description'] == 'Error'
-    assert weather_data['humidity'] == '--'
-    assert 'time' in weather_data
-    assert weather_data['icon'] == 'unknown'
+def test_get_weather_success(weather_service, weather_data):
+    service, provider, _factory = weather_service
+    provider.get_weather.return_value = weather_data
 
-@pytest.mark.parametrize("aqi_value,expected_label", [
-    (1, "Good"),
-    (2, "Fair"),
-    (3, "Moderate"),
-    (4, "Poor"),
-    (5, "Very Poor")
-])
-def test_air_quality_labels(weather_service, aqi_value, expected_label):
-    """Test air quality index labels"""
-    assert weather_service.aqi_labels[aqi_value] == expected_label
+    result = service.get_weather()
 
-@responses.activate
-def test_get_air_quality_success(weather_service, mock_responses, mock_env_vars):
-    """Test successful air quality data retrieval"""
-    mock_air_quality_response = {
-        "list": [{
-            "main": {"aqi": 1},
-            "components": {
-                "co": 200.34,
-                "no2": 2.95,
-                "o3": 60.84,
-                "pm2_5": 4.11,
-                "pm10": 7.32
-            }
-        }]
+    assert result["temperature"] == 15.3
+    assert result["description"] == "Clear sky"
+    assert result["humidity"] == 65
+    assert result["icon"] == "sun"
+    assert result["feels_like"] == 14.8
+    assert result["pressure"] == 1015
+    assert result["daily_forecast"] == weather_data.daily_forecast
+
+
+def test_get_weather_api_error(weather_service):
+    service, provider, _factory = weather_service
+    provider.get_weather.side_effect = RuntimeError("API error")
+
+    result = service.get_weather()
+
+    assert result["temperature"] == "--"
+    assert result["description"] == "Error"
+    assert result["humidity"] == "--"
+    assert result["icon"] == "unknown"
+    assert "time" in result
+
+
+def test_get_air_quality_success(weather_service, weather_data):
+    service, provider, _factory = weather_service
+    provider.get_weather.return_value = weather_data
+
+    assert service.get_air_quality() == {
+        "aqi": 1,
+        "aqi_label": "Good",
+        "components": {"pm2_5": 4.11},
     }
 
-    mock_responses.add(
-        responses.GET,
-        weather_service.air_pollution_url,
-        match=[
-            responses.matchers.query_param_matcher({
-                'lat': str(float(weather_service.lat)),
-                'lon': str(float(weather_service.lon)),
-                'appid': mock_env_vars['OPENWEATHER_API_KEY']
-            })
-        ],
-        json=mock_air_quality_response,
-        status=200
+
+def test_get_air_quality_without_data(weather_service, weather_data):
+    service, provider, _factory = weather_service
+    provider.get_weather.return_value = weather_data.model_copy(
+        update={"air_quality": None}
     )
 
-    air_quality = weather_service.get_air_quality()
-    
-    assert air_quality is not None
-    assert air_quality['aqi'] == 1
-    assert air_quality['aqi_label'] == "Good"
-    assert 'components' in air_quality
+    assert service.get_air_quality() is None


### PR DESCRIPTION
## Summary

- normalize generated display-color ratios so every dither mix sums to 1
- make pytest discovery deterministic and isolate tests from the developer's real home and `.env` files
- replace stale bus and weather tests with coverage for the current provider and backoff APIs
- keep astronomy tests offline by using a deterministic fake ephemeris
- align display, factory, and OpenWeather assertions with current behavior

## Root cause

The suite combined a genuine color-ratio defect with several generations of stale tests. Tests still mocked the old `requests` and weather-module interfaces after the application moved to `niquests`, provider models, and dedicated backoff objects. Astronomy tests also attempted to download ephemeris data, and pytest collected a root-level visual test helper before the intended test package.

## Impact

`pytest` now runs offline and no longer reads, replaces, or backs up a developer's real configuration files. The production behavior change is limited to normalizing dither color ratios at the public helper boundary.

## Validation

- `/tmp/rpi-waiting-tests/bin/pytest -q` — 178 passed
- `git diff --check` — clean