### PR TITLE
Add a shared screen ownership arbiter

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -89,6 +89,12 @@ iss_check_interval = 30
 # Priority of the ISS display over the bus display. If true, the ISS display will be shown instead of the bus display when the ISS is overhead.
 iss_priority = true
 
+# Optional display-plugin priorities. Higher values pre-empt lower values. If
+# screen_priority_iss is omitted, legacy iss_priority=true places ISS above
+# flights and false places it below flights.
+screen_priority_flight=50
+screen_priority_iss=60
+
 # Weather settings
 WEATHER_PROVIDER=openmeteo  # openmeteo or openweather
 OPENWEATHER_API_KEY=  # Only needed if using openweather provider

--- a/basic.py
+++ b/basic.py
@@ -28,6 +28,7 @@ from token_usage import (
     configured_token_views,
     token_view_at,
 )
+from screen_arbiter import ScreenArbiter
 
 logger = logging.getLogger(__name__)
 # Set logging level for PIL.PngImagePlugin and urllib3.connectionpool to warning
@@ -260,6 +261,9 @@ class BusManager:
             return self.bus_data.get('stop_name')
 
 class DisplayManager:
+    FLIGHT_SCREEN_OWNER = "flight"
+    ISS_SCREEN_OWNER = "iss"
+
     def __init__(self, epd):
         self.epd = epd
         self.update_count = 0
@@ -299,6 +303,13 @@ class DisplayManager:
         self.in_iss_mode = False
         self.iss_mode_start_time = None
         self.iss_mode_max_seconds = int(os.getenv("iss_mode_max_seconds", "3600"))
+        self.flight_screen_priority = int(os.getenv("screen_priority_flight", "50"))
+        default_iss_priority = "60" if self.iss_priority else "40"
+        self.iss_screen_priority = int(
+            os.getenv("screen_priority_iss", default_iss_priority)
+        )
+        self.screen_arbiter = ScreenArbiter()
+        self._last_screen_owner = None
         self.prefetch_offset = 10  # seconds before display update to fetch new data
         self.display_interval = DISPLAY_REFRESH_INTERVAL
         self.next_update_time = None
@@ -311,6 +322,11 @@ class DisplayManager:
         logger.info(f"DisplayManager initialized with min refresh interval: {self.min_refresh_interval}s")
         logger.info(f"DisplayManager initialized with coordinates: {self.coordinates_lat}, {self.coordinates_lng}")
         logger.info(f"DisplayManager initialized with flight mode duration: {self.flight_mode_duration}s")
+        logger.info(
+            "Screen priorities initialized: flight=%s, iss=%s",
+            self.flight_screen_priority,
+            self.iss_screen_priority,
+        )
         if self.token_usage_client.enabled:
             logger.info("Token usage display enabled with views: %s", ", ".join(self.token_views))
 
@@ -398,11 +414,12 @@ class DisplayManager:
             flight_check_interval=flight_check_interval,
             aeroapi_enabled=aeroapi_enabled
         )
-        self.flight_thread = threading.Thread(
+        self._flight_thread = threading.Thread(
             target=self._check_flights,
+            name="FlightTracker",
             daemon=True
         )
-        self.flight_thread.start()
+        self._flight_thread.start()
 
     def initialize_iss_tracking(self):
         if not self.iss_enabled:
@@ -425,27 +442,44 @@ class DisplayManager:
     def _run_iss_tracker(self):
         """Run ISS tracker with display mode management"""
         def on_pass_start():
-            if self.iss_priority:
-                # Force exit from flight mode if needed
-                if self.in_flight_mode:
-                    logger.info("ISS pass starting - forcing exit from flight mode")
-                    self.in_flight_mode = False
-                    self.flight_mode_start = None
             self.in_iss_mode = True
             self.iss_mode_start_time = datetime.now()
+            self.screen_arbiter.claim(
+                self.ISS_SCREEN_OWNER,
+                self.iss_screen_priority,
+                self.iss_mode_max_seconds,
+            )
             
         def on_pass_end():
             self.in_iss_mode = False
             self.iss_mode_start_time = None
-            self._force_display_update()
+            self.screen_arbiter.release(self.ISS_SCREEN_OWNER)
+
+        def display_position(position):
+            if not self.screen_arbiter.can_render(self.ISS_SCREEN_OWNER):
+                return False
+            from iss import display_iss_info
+
+            with self._display_lock:
+                if not self.screen_arbiter.can_render(self.ISS_SCREEN_OWNER):
+                    return False
+                display_iss_info(self.epd, position)
+                self.last_display_update = datetime.now()
+                self.current_display_mode = self.ISS_SCREEN_OWNER
+            return True
 
         try:
-            self.iss_tracker.run(self.epd, on_pass_start, on_pass_end)
+            self.iss_tracker.run(
+                self.epd,
+                on_pass_start,
+                on_pass_end,
+                display_callback=display_position,
+            )
         except Exception as e:
             logger.error(f"Error in ISS tracker: {e}")
             self.in_iss_mode = False
             self.iss_mode_start_time = None
-            self._force_display_update()
+            self.screen_arbiter.release(self.ISS_SCREEN_OWNER)
 
     def _can_enter_flight_mode(self, current_time):
         """Check if we can enter flight mode based on cooldown"""
@@ -502,11 +536,24 @@ class DisplayManager:
                                             logger.debug("Entering flight mode")
                                             self.in_flight_mode = True
                                             self.flight_mode_start = current_time
+                                            self.screen_arbiter.claim(
+                                                self.FLIGHT_SCREEN_OWNER,
+                                                self.flight_screen_priority,
+                                                self.flight_mode_duration,
+                                            )
                                             logger.debug(f"Flight mode start time: {self.flight_mode_start}")
                                         else:
                                             logger.debug("Updating flight display while in flight mode")
-                                        update_display_with_flights(self.epd, [enhanced_flight])
-                                    self.last_display_update = datetime.now()
+                                        if self.screen_arbiter.can_render(
+                                            self.FLIGHT_SCREEN_OWNER
+                                        ):
+                                            update_display_with_flights(
+                                                self.epd, [enhanced_flight]
+                                            )
+                                            self.current_display_mode = (
+                                                self.FLIGHT_SCREEN_OWNER
+                                            )
+                                            self.last_display_update = datetime.now()
                                     self.last_flight_update = current_time
                         else:
                             logger.debug("No flights found within the radius")
@@ -523,14 +570,22 @@ class DisplayManager:
         """Force an immediate display update"""
         logger.info("Forcing initial display update...")
         try:
+            if not self.screen_arbiter.can_render():
+                logger.debug(
+                    "Base display update deferred while %s owns the screen",
+                    self.screen_arbiter.active_owner(),
+                )
+                return False
             with self._display_lock:
+                if not self.screen_arbiter.can_render():
+                    return False
                 current_time = datetime.now()
                 scheduled_mode = self._scheduled_mode(current_time)
                 if self._is_token_mode(scheduled_mode) and self._draw_token_usage(
                     current_time, require_active=scheduled_mode == "token"
                 ):
                     self.last_display_update = current_time
-                    return
+                    return True
                 if self._is_token_mode(scheduled_mode):
                     scheduled_mode = self._token_fallback_mode()
                 bus_data, error_message, stop_name = self.bus_manager.get_bus_data()
@@ -584,9 +639,11 @@ class DisplayManager:
                     logger.warning("No valid data for initial display")
                 
                 self.last_display_update = datetime.now()
+                return True
         except Exception as e:
             logger.error(f"Error in initial display update: {e}")
             logger.debug(traceback.format_exc())
+            return False
 
     def _can_update_display(self, current_time):
         """Check if enough time has passed since last display update"""
@@ -609,21 +666,21 @@ class DisplayManager:
 
         while not self._stop_event.is_set():
             try:
-                if self.in_iss_mode:
-                    if self.iss_mode_start_time:
-                        time_in_iss_mode = (datetime.now() - self.iss_mode_start_time).total_seconds()
-                        if time_in_iss_mode >= self.iss_mode_max_seconds:
-                            logger.warning(f"ISS mode watchdog triggered after {time_in_iss_mode:.1f}s (max {self.iss_mode_max_seconds}s) - forcing exit from ISS mode")
-                            self.in_iss_mode = False
-                            self.iss_mode_start_time = None
-                            self._force_display_update()
-                            time.sleep(1)
-                            continue
-                    # Skip normal updates during ISS passes
-                    time.sleep(1)
-                    continue
-                
                 current_time = datetime.now()
+
+                if self.in_iss_mode and self.iss_mode_start_time:
+                    time_in_iss_mode = (
+                        current_time - self.iss_mode_start_time
+                    ).total_seconds()
+                    if time_in_iss_mode >= self.iss_mode_max_seconds:
+                        logger.warning(
+                            "ISS mode watchdog triggered after %.1fs (max %ss)",
+                            time_in_iss_mode,
+                            self.iss_mode_max_seconds,
+                        )
+                        self.in_iss_mode = False
+                        self.iss_mode_start_time = None
+                        self.screen_arbiter.release(self.ISS_SCREEN_OWNER)
 
                 # Handle flight mode checks
                 with self._flight_lock:
@@ -637,11 +694,14 @@ class DisplayManager:
                             self.in_flight_mode = False
                             self.last_flight_mode_end = current_time
                             self.flight_mode_start = None
+                            self.screen_arbiter.release(self.FLIGHT_SCREEN_OWNER)
                             logger.info(f"Starting flight cooldown period of {self.flight_mode_cooldown} seconds")
-                            # Force an immediate update to normal display
-                            self._force_display_update()
-                        time.sleep(1)  # Add sleep when in flight mode
-                        continue
+
+                active_owner = self.screen_arbiter.active_owner()
+                if self._last_screen_owner and active_owner is None:
+                    self._force_display_update()
+                    self._schedule_next_update()
+                self._last_screen_owner = active_owner
 
                 # Check if it's time to prefetch data
                 if (
@@ -662,7 +722,10 @@ class DisplayManager:
                                 # We want to avoid infinite retry loops within the same cycle
 
                 # Check if it's time to update display
-                if current_time >= self.next_update_time:
+                if (
+                    current_time >= self.next_update_time
+                    and self.screen_arbiter.can_render()
+                ):
                     logger.debug("Updating display...")
                     weather_data = self.weather_manager.get_weather_data() if weather_enabled else None
                     valid_bus_data = self.bus_manager.get_valid_bus_data() if transit_enabled else None
@@ -670,6 +733,8 @@ class DisplayManager:
                     stop_name = self.bus_manager.get_stop_name() if transit_enabled else None
 
                     with self._display_lock:
+                        if not self.screen_arbiter.can_render():
+                            continue
                         scheduled_mode = self._scheduled_mode(current_time)
                         if self._is_token_mode(scheduled_mode):
                             if self._draw_token_usage(
@@ -810,8 +875,7 @@ class DisplayManager:
         self.in_flight_mode = False
         self.flight_mode_start = None
         self.last_flight_mode_end = datetime.now()
-        # Force an immediate update to normal display
-        self._force_display_update()
+        self.screen_arbiter.release(self.FLIGHT_SCREEN_OWNER)
 
 def main():
     epd = None

--- a/basic.py
+++ b/basic.py
@@ -694,6 +694,7 @@ class DisplayManager:
                             self.in_flight_mode = False
                             self.last_flight_mode_end = current_time
                             self.flight_mode_start = None
+                            last_flight_log = 0
                             self.screen_arbiter.release(self.FLIGHT_SCREEN_OWNER)
                             logger.info(f"Starting flight cooldown period of {self.flight_mode_cooldown} seconds")
 
@@ -734,6 +735,8 @@ class DisplayManager:
 
                     with self._display_lock:
                         if not self.screen_arbiter.can_render():
+                            with self._prefetch_lock:
+                                self.prefetch_done = False
                             continue
                         scheduled_mode = self._scheduled_mode(current_time)
                         if self._is_token_mode(scheduled_mode):

--- a/docs/screen-arbiter.md
+++ b/docs/screen-arbiter.md
@@ -1,0 +1,27 @@
+# Screen ownership arbiter
+
+The scheduled transit, weather, or token screen is the base display. Optional
+plugins must claim the screen through `ScreenArbiter` before rendering an
+interrupting view.
+
+A claim has four properties:
+
+- `owner`: a stable, unique plugin name;
+- `priority`: a larger number wins;
+- `ttl_seconds`: a mandatory expiry that prevents a failed plugin from holding
+  the display indefinitely;
+- `exclusive`: when true, a winning claim cannot be pre-empted before it is
+  released or expires.
+
+Claims remain registered while another plugin is active. When the winning claim
+ends, the next-highest claim resumes automatically; if no claims remain, the
+normal scheduled display is restored.
+
+## Existing plugin priorities
+
+Flights default to priority `50`. ISS defaults to `60` when the existing
+`iss_priority=true` setting is used, or `40` when it is false. Set
+`screen_priority_flight` or `screen_priority_iss` to override those values.
+
+Future plugins should use bounded claims and check `can_render(owner)` again
+while holding the display lock immediately before writing to the device.

--- a/docs/screen-arbiter.md
+++ b/docs/screen-arbiter.md
@@ -14,8 +14,16 @@ A claim has four properties:
   released or expires.
 
 Claims remain registered while another plugin is active. When the winning claim
-ends, the next-highest claim resumes automatically; if no claims remain, the
-normal scheduled display is restored.
+ends, the next-highest claim becomes eligible automatically; if no claims
+remain, the normal scheduled display is restored.
+
+The arbiter manages ownership, not a retained image layer. An e-ink panel keeps
+showing the last pixels written by the previous owner until the resumed plugin
+renders again. Interrupting plugins must therefore detect when
+`can_render(owner)` becomes true and redraw immediately, or poll frequently
+enough for their use case. The built-in flight and ISS plugins update
+periodically, while the display manager explicitly redraws the base screen when
+the final claim ends.
 
 ## Existing plugin priorities
 

--- a/iss.py
+++ b/iss.py
@@ -96,7 +96,7 @@ class ISSTracker:
             logger.error(f"Error calculating passes: {e}")
             self.next_passes = []
 
-    def monitor_pass(self, pass_info, epd):
+    def monitor_pass(self, pass_info, epd, display_callback=None):
         """Monitor ISS during a pass window"""
         start_time = pass_info['risetime']
         end_time = start_time + pass_info['duration']
@@ -107,8 +107,13 @@ class ISSTracker:
             is_visible, position = is_iss_near(Coordinates_LAT, Coordinates_LNG, debug=True)
             if position:
                 try:
-                    display_iss_info(epd, position)
-                    logger.debug(f"Updated display with position: {position}")
+                    displayed = (
+                        display_callback(position)
+                        if display_callback
+                        else display_iss_info(epd, position)
+                    )
+                    if displayed is not False:
+                        logger.debug(f"Updated display with position: {position}")
                 except Exception as e:
                     logger.error(f"Error updating ISS display: {e}")
             
@@ -116,7 +121,13 @@ class ISSTracker:
         
         logger.info(f"Completed pass monitoring at {datetime.now()}")
 
-    def run(self, epd, on_pass_start=None, on_pass_end=None):
+    def run(
+        self,
+        epd,
+        on_pass_start=None,
+        on_pass_end=None,
+        display_callback=None,
+    ):
         """Main running loop with callbacks"""
         while not self.stop_event.is_set():
             current_time = time()
@@ -134,7 +145,11 @@ class ISSTracker:
                     if on_pass_start:
                         on_pass_start()
                     try:
-                        self.monitor_pass(current_pass, epd)
+                        self.monitor_pass(
+                            current_pass,
+                            epd,
+                            display_callback=display_callback,
+                        )
                     except Exception as e:
                         logger.error(f"Error monitoring ISS pass: {e}")
                     finally:

--- a/screen_arbiter.py
+++ b/screen_arbiter.py
@@ -1,0 +1,149 @@
+"""Thread-safe ownership arbitration for display plugins.
+
+The normal scheduled display is the implicit base layer. Optional plugins claim
+the screen for a bounded amount of time and may be pre-empted by a higher
+priority claim. An exclusive winning claim stays in control until it is
+released or expires, which gives urgent screens a safe lock without allowing a
+plugin failure to hold the display forever.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+import time
+from dataclasses import dataclass
+from typing import Callable, Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class ScreenClaim:
+    owner: str
+    priority: int
+    expires_at: float
+    exclusive: bool = False
+    sequence: int = 0
+
+
+class ScreenArbiter:
+    """Choose which optional display plugin currently owns the screen."""
+
+    def __init__(self, clock: Callable[[], float] = time.monotonic):
+        self._clock = clock
+        self._claims: Dict[str, ScreenClaim] = {}
+        self._current_owner: Optional[str] = None
+        self._sequence = 0
+        self._lock = threading.RLock()
+
+    def claim(
+        self,
+        owner: str,
+        priority: int,
+        ttl_seconds: float,
+        *,
+        exclusive: bool = False,
+    ) -> bool:
+        """Create or refresh a claim and return whether it is active."""
+
+        owner = owner.strip()
+        if not owner:
+            raise ValueError("screen claim owner must not be empty")
+        if ttl_seconds <= 0:
+            raise ValueError("screen claim ttl_seconds must be positive")
+
+        with self._lock:
+            self._prune_expired()
+            existing = self._claims.get(owner)
+            if existing:
+                sequence = existing.sequence
+            else:
+                self._sequence += 1
+                sequence = self._sequence
+            self._claims[owner] = ScreenClaim(
+                owner=owner,
+                priority=int(priority),
+                expires_at=self._clock() + float(ttl_seconds),
+                exclusive=exclusive,
+                sequence=sequence,
+            )
+            previous = self._current_owner
+            self._select_owner()
+            self._log_transition(previous)
+            return self._current_owner == owner
+
+    def release(self, owner: str) -> bool:
+        """Remove a claim and return whether its owner controlled the screen."""
+
+        with self._lock:
+            self._prune_expired()
+            was_active = self._current_owner == owner
+            previous = self._current_owner
+            self._claims.pop(owner, None)
+            if was_active:
+                self._current_owner = None
+            self._select_owner()
+            self._log_transition(previous)
+            return was_active
+
+    def active_owner(self) -> Optional[str]:
+        """Return the active plugin owner, or ``None`` for the base display."""
+
+        with self._lock:
+            previous = self._current_owner
+            self._prune_expired()
+            self._select_owner()
+            self._log_transition(previous)
+            return self._current_owner
+
+    def can_render(self, owner: Optional[str] = None) -> bool:
+        """Return whether an owner may render; ``None`` means the base layer."""
+
+        return self.active_owner() == owner
+
+    def has_claim(self, owner: str) -> bool:
+        with self._lock:
+            self._prune_expired()
+            return owner in self._claims
+
+    def claim_for(self, owner: str) -> Optional[ScreenClaim]:
+        with self._lock:
+            self._prune_expired()
+            return self._claims.get(owner)
+
+    def _prune_expired(self) -> None:
+        now = self._clock()
+        expired = [
+            owner for owner, claim in self._claims.items() if claim.expires_at <= now
+        ]
+        for owner in expired:
+            self._claims.pop(owner, None)
+            if self._current_owner == owner:
+                self._current_owner = None
+
+    def _select_owner(self) -> None:
+        current = self._claims.get(self._current_owner or "")
+        if current and current.exclusive:
+            return
+        if not self._claims:
+            self._current_owner = None
+            return
+        # Existing ownership wins an equal-priority tie. Otherwise the older
+        # claim wins, preventing same-priority plugins from flickering.
+        self._current_owner = min(
+            self._claims.values(),
+            key=lambda claim: (
+                -claim.priority,
+                0 if claim.owner == self._current_owner else 1,
+                claim.sequence,
+            ),
+        ).owner
+
+    def _log_transition(self, previous: Optional[str]) -> None:
+        if previous != self._current_owner:
+            logger.info(
+                "Screen ownership changed: %s -> %s",
+                previous or "base",
+                self._current_owner or "base",
+            )

--- a/tests/test_screen_arbiter.py
+++ b/tests/test_screen_arbiter.py
@@ -1,0 +1,104 @@
+import pytest
+
+from screen_arbiter import ScreenArbiter
+
+
+class FakeClock:
+    def __init__(self):
+        self.now = 100.0
+
+    def __call__(self):
+        return self.now
+
+    def advance(self, seconds):
+        self.now += seconds
+
+
+def test_base_display_is_active_without_claims():
+    arbiter = ScreenArbiter()
+
+    assert arbiter.active_owner() is None
+    assert arbiter.can_render()
+    assert not arbiter.can_render("flight")
+
+
+def test_higher_priority_claim_preempts_and_release_restores_previous_owner():
+    clock = FakeClock()
+    arbiter = ScreenArbiter(clock)
+
+    assert arbiter.claim("calendar-upcoming", 30, 300)
+    assert arbiter.claim("flight", 50, 30)
+    assert arbiter.active_owner() == "flight"
+
+    assert arbiter.release("flight")
+    assert arbiter.active_owner() == "calendar-upcoming"
+
+
+def test_expiry_returns_control_to_base():
+    clock = FakeClock()
+    arbiter = ScreenArbiter(clock)
+    arbiter.claim("flight", 50, 30)
+
+    clock.advance(30)
+
+    assert arbiter.active_owner() is None
+    assert arbiter.can_render()
+    assert not arbiter.has_claim("flight")
+
+
+def test_exclusive_winner_cannot_be_preempted_but_must_expire():
+    clock = FakeClock()
+    arbiter = ScreenArbiter(clock)
+    arbiter.claim("calendar-exclusive", 70, 600, exclusive=True)
+
+    assert not arbiter.claim("emergency", 100, 60)
+    assert arbiter.active_owner() == "calendar-exclusive"
+
+    clock.advance(600)
+
+    assert arbiter.active_owner() is None
+
+
+def test_exclusive_claim_waits_for_a_higher_priority_current_owner():
+    arbiter = ScreenArbiter()
+    arbiter.claim("flight", 50, 30)
+
+    assert not arbiter.claim("low-exclusive", 20, 60, exclusive=True)
+    assert arbiter.active_owner() == "flight"
+
+    arbiter.release("flight")
+    assert arbiter.active_owner() == "low-exclusive"
+
+
+def test_equal_priority_keeps_current_owner_until_release():
+    arbiter = ScreenArbiter()
+    arbiter.claim("first", 50, 30)
+    arbiter.claim("second", 50, 30)
+
+    assert arbiter.active_owner() == "first"
+    arbiter.release("first")
+    assert arbiter.active_owner() == "second"
+
+
+def test_refreshing_claim_extends_expiry_without_changing_tie_order():
+    clock = FakeClock()
+    arbiter = ScreenArbiter(clock)
+    arbiter.claim("first", 50, 10)
+    arbiter.claim("second", 50, 30)
+    clock.advance(5)
+
+    arbiter.claim("first", 50, 20)
+    clock.advance(10)
+
+    assert arbiter.active_owner() == "first"
+
+
+@pytest.mark.parametrize("owner", ["", "   "])
+def test_claim_rejects_empty_owner(owner):
+    with pytest.raises(ValueError):
+        ScreenArbiter().claim(owner, 1, 1)
+
+
+def test_claim_rejects_non_positive_ttl():
+    with pytest.raises(ValueError):
+        ScreenArbiter().claim("flight", 1, 0)


### PR DESCRIPTION
## What changed

- add a thread-safe `ScreenArbiter` for bounded, prioritized plugin claims
- support exclusive claims that cannot be pre-empted before release or expiry
- migrate flight and ISS screen ownership to the arbiter
- keep scheduled transit, weather, and token views as the implicit base layer
- restore the base display automatically after the final plugin claim ends
- document priority configuration and the provider contract

## Why

Flight and ISS currently manage screen ownership through independent mode flags and direct display writes. Adding another interrupting provider, such as calendar reminders, would create more overlapping control paths. The arbiter gives every optional provider one shared priority and expiry model while preserving the existing scheduled base display.

## User and developer impact

Existing installations keep their current behavior. `iss_priority` remains backward-compatible, while `screen_priority_flight` and `screen_priority_iss` allow explicit ordering. New plugins can use bounded claims without adding another global mode flag.

## Validation

- `196 passed` with the full pytest suite
- Black check on the new arbiter and tests
- Flake8 on the new arbiter and tests with Black's 88-character line length
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added coordinated screen ownership for flight, ISS, and scheduled displays, preventing competing updates from overwriting one another.
  - Flight and ISS views now take priority when appropriate and automatically return control to normal scheduled content.
  - Added optional configuration for flight and ISS display priorities, including legacy ISS priority compatibility.
  - ISS tracking now supports customized display handling.

- **Documentation**
  - Added guidance for configuring and extending display priority behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->