### PR TITLE
Add configurable calendar display plugin

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -95,6 +95,35 @@ iss_priority = true
 screen_priority_flight=50
 screen_priority_iss=60
 
+# Optional read-only calendar display. Google Calendar exposes the URL under
+# Settings -> Integrate calendar -> Secret address in iCal format. Treat the
+# URL like a password and store it only in the ignored .env file.
+calendar_enabled=false
+calendar_source=ics
+calendar_ics_urls=
+calendar_timezone=Europe/Brussels
+calendar_refresh_interval=300
+calendar_poll_seconds=1
+calendar_timeout=10
+calendar_max_stale_seconds=21600
+calendar_cache_dir=cache
+calendar_lookahead_days=3
+calendar_include_all_day=false
+calendar_show_details=true
+
+# Event cards own the display for the final hour but remain below flight/ISS
+# defaults until the exclusive final ten minutes. Agenda glances run for one
+# minute every half hour and then return to the scheduled base screen.
+calendar_lead_minutes=60
+calendar_exclusive_enabled=true
+calendar_exclusive_minutes=10
+calendar_priority_agenda=20
+calendar_priority_upcoming=40
+calendar_priority_exclusive=100
+calendar_agenda_interval_seconds=1800
+calendar_agenda_duration_seconds=60
+calendar_agenda_max_events=4
+
 # Weather settings
 WEATHER_PROVIDER=openmeteo  # openmeteo or openweather
 OPENWEATHER_API_KEY=  # Only needed if using openweather provider

--- a/basic.py
+++ b/basic.py
@@ -29,6 +29,7 @@ from token_usage import (
     token_view_at,
 )
 from screen_arbiter import ScreenArbiter
+from calendar_plugin import CalendarPlugin
 
 logger = logging.getLogger(__name__)
 # Set logging level for PIL.PngImagePlugin and urllib3.connectionpool to warning
@@ -319,6 +320,12 @@ class DisplayManager:
         self.token_views = configured_token_views()
         self.current_display_mode = None
         self.current_token_view = None
+        self.calendar_plugin = CalendarPlugin(
+            epd,
+            self.screen_arbiter,
+            self._display_lock,
+            on_render=self._calendar_rendered,
+        )
         logger.info(f"DisplayManager initialized with min refresh interval: {self.min_refresh_interval}s")
         logger.info(f"DisplayManager initialized with coordinates: {self.coordinates_lat}, {self.coordinates_lng}")
         logger.info(f"DisplayManager initialized with flight mode duration: {self.flight_mode_duration}s")
@@ -329,6 +336,12 @@ class DisplayManager:
         )
         if self.token_usage_client.enabled:
             logger.info("Token usage display enabled with views: %s", ", ".join(self.token_views))
+
+    def _calendar_rendered(self, owner):
+        self.current_display_mode = owner
+        self.current_token_view = None
+        self.in_weather_mode = False
+        self.last_display_update = datetime.now()
 
     def _scheduled_mode(self, current_time):
         if not self.token_usage_client.enabled:
@@ -388,6 +401,10 @@ class DisplayManager:
         
         # Initialize ISS tracking if enabled
         self.initialize_iss_tracking()
+
+        # Calendar events are fetched and rendered independently of the base
+        # transit/weather/token data sources.
+        self.calendar_plugin.start()
         
         # Token views do not depend on transit either. The normal update loop
         # will prefetch it when a transit or automatic window becomes active.
@@ -860,6 +877,8 @@ class DisplayManager:
         
         if self.iss_tracker:
             self.iss_tracker.stop()
+
+        self.calendar_plugin.stop()
             
         for thread in [self._check_data_thread, self._flight_thread, self._iss_thread]:
             if thread:

--- a/calendar_display.py
+++ b/calendar_display.py
@@ -1,0 +1,158 @@
+"""Compact e-paper views for upcoming calendar events."""
+
+from __future__ import annotations
+
+import math
+import os
+from datetime import datetime, timedelta
+from typing import Iterable
+
+from PIL import Image, ImageDraw, ImageFont
+
+from calendar_service import CalendarEvent
+from display_adapter import return_display_lock
+from font_utils import get_font_paths
+
+display_lock = return_display_lock()
+DISPLAY_SCREEN_ROTATION = int(os.getenv("screen_rotation", 90))
+
+
+def _fonts():
+    paths = get_font_paths()
+    try:
+        return (
+            ImageFont.truetype(paths["dejavu_bold"], 13),
+            ImageFont.truetype(paths["dejavu_bold"], 15),
+            ImageFont.truetype(paths["dejavu"], 10),
+            ImageFont.truetype(paths["dejavu_bold"], 27),
+        )
+    except OSError:
+        fallback = ImageFont.load_default()
+        return fallback, fallback, fallback, fallback
+
+
+def _canvas(epd):
+    white = epd.WHITE if not epd.is_bw_display else 1
+    black = epd.BLACK if not epd.is_bw_display else 0
+    image = Image.new(
+        "1" if epd.is_bw_display else "RGB",
+        (epd.height, epd.width),
+        white,
+    )
+    return image, ImageDraw.Draw(image), black
+
+
+def _finish(epd, image, set_base_image: bool):
+    image = image.rotate(DISPLAY_SCREEN_ROTATION, expand=True)
+    with display_lock:
+        buffer = epd.getbuffer(image)
+        if hasattr(epd, "displayPartial"):
+            if set_base_image and hasattr(epd, "displayPartBaseImage"):
+                epd.init()
+                epd.displayPartBaseImage(buffer)
+            else:
+                epd.displayPartial(buffer)
+        else:
+            epd.display(buffer)
+
+
+def _ellipsize(draw, text: str, font, max_width: int) -> str:
+    text = " ".join(text.split())
+    if draw.textbbox((0, 0), text, font=font)[2] <= max_width:
+        return text
+    while text and draw.textbbox((0, 0), f"{text}…", font=font)[2] > max_width:
+        text = text[:-1]
+    return f"{text.rstrip()}…" if text else "…"
+
+
+def _wrap_two_lines(draw, text: str, font, max_width: int):
+    words = " ".join(text.split()).split(" ")
+    lines = []
+    while words and len(lines) < 2:
+        current = ""
+        while words:
+            candidate = f"{current} {words[0]}".strip()
+            if current and draw.textbbox((0, 0), candidate, font=font)[2] > max_width:
+                break
+            current = candidate
+            words.pop(0)
+            if draw.textbbox((0, 0), current, font=font)[2] > max_width:
+                current = _ellipsize(draw, current, font, max_width)
+                break
+        if len(lines) == 1 and words:
+            current = _ellipsize(
+                draw,
+                f"{current} {' '.join(words)}",
+                font,
+                max_width,
+            )
+            words.clear()
+        if current:
+            lines.append(current)
+    return lines[:2]
+
+
+def draw_upcoming_event(
+    epd,
+    event: CalendarEvent,
+    now: datetime,
+    *,
+    set_base_image: bool = False,
+):
+    image, draw, black = _canvas(epd)
+    header, title_font, tiny, countdown_font = _fonts()
+    status = "STALE" if event.stale else event.start.strftime("%H:%M")
+    draw.text((7, 5), "CALENDAR", font=header, fill=black)
+    status_width = draw.textbbox((0, 0), status, font=tiny)[2]
+    draw.text((243 - status_width, 7), status, font=tiny, fill=black)
+    draw.line((7, 24, 243, 24), fill=black, width=1)
+
+    for index, line in enumerate(_wrap_two_lines(draw, event.summary, title_font, 236)):
+        draw.text((7, 29 + index * 17), line, font=title_font, fill=black)
+    if event.location:
+        location = _ellipsize(draw, event.location, tiny, 236)
+        draw.text((7, 65), location, font=tiny, fill=black)
+
+    seconds = max(0, (event.start - now).total_seconds())
+    minutes = math.ceil(seconds / 60)
+    countdown = "STARTS NOW" if minutes == 0 else f"IN {minutes} MIN"
+    width = draw.textbbox((0, 0), countdown, font=countdown_font)[2]
+    draw.text(((250 - width) // 2, 82), countdown, font=countdown_font, fill=black)
+    _finish(epd, image, set_base_image)
+
+
+def _event_time_label(event: CalendarEvent, now: datetime) -> str:
+    if event.start.date() == now.date():
+        day = "TODAY"
+    elif event.start.date() == (now.date() + timedelta(days=1)):
+        day = "TOM"
+    else:
+        day = event.start.strftime("%a").upper()
+    return f"{day} ALL" if event.all_day else f"{day} {event.start:%H:%M}"
+
+
+def draw_calendar_agenda(
+    epd,
+    events: Iterable[CalendarEvent],
+    now: datetime,
+    *,
+    set_base_image: bool = False,
+):
+    events = list(events)
+    image, draw, black = _canvas(epd)
+    header, title_font, tiny, _ = _fonts()
+    status = "STALE" if any(event.stale for event in events) else now.strftime("%H:%M")
+    draw.text((7, 5), "UPCOMING", font=header, fill=black)
+    status_width = draw.textbbox((0, 0), status, font=tiny)[2]
+    draw.text((243 - status_width, 7), status, font=tiny, fill=black)
+    draw.line((7, 24, 243, 24), fill=black, width=1)
+
+    for index, event in enumerate(events[:4]):
+        y = 29 + index * 23
+        label = _event_time_label(event, now)
+        draw.text((7, y + 2), label, font=tiny, fill=black)
+        title = _ellipsize(draw, event.summary, title_font, 160)
+        draw.text((82, y), title, font=title_font, fill=black)
+        if index < min(len(events), 4) - 1:
+            draw.line((7, y + 20, 243, y + 20), fill=black, width=1)
+    _finish(epd, image, set_base_image)

--- a/calendar_display.py
+++ b/calendar_display.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import math
 import os
 from datetime import datetime, timedelta
+from functools import lru_cache
 from typing import Iterable
 
 from PIL import Image, ImageDraw, ImageFont
@@ -17,6 +18,7 @@ display_lock = return_display_lock()
 DISPLAY_SCREEN_ROTATION = int(os.getenv("screen_rotation", 90))
 
 
+@lru_cache(maxsize=1)
 def _fonts():
     paths = get_font_paths()
     try:

--- a/calendar_plugin.py
+++ b/calendar_plugin.py
@@ -1,0 +1,193 @@
+"""Calendar display provider backed by the shared screen arbiter."""
+
+from __future__ import annotations
+
+import logging
+import os
+import threading
+from datetime import datetime
+from typing import Callable, Iterable, Optional
+
+from calendar_display import draw_calendar_agenda, draw_upcoming_event
+from calendar_service import CalendarClient, CalendarEvent
+
+logger = logging.getLogger(__name__)
+
+
+def _enabled(name: str, default: str = "false") -> bool:
+    return os.getenv(name, default).strip().lower() == "true"
+
+
+class CalendarPlugin:
+    EVENT_OWNER = "calendar-event"
+    AGENDA_OWNER = "calendar-agenda"
+
+    def __init__(
+        self,
+        epd,
+        arbiter,
+        display_lock,
+        *,
+        client: Optional[CalendarClient] = None,
+        on_render: Optional[Callable[[str], None]] = None,
+    ):
+        self.epd = epd
+        self.arbiter = arbiter
+        self.display_lock = display_lock
+        self.client = client or CalendarClient()
+        self.on_render = on_render
+        self.enabled = self.client.enabled
+        self.poll_seconds = max(1, int(os.getenv("calendar_poll_seconds", "1")))
+        self.claim_ttl = max(5, self.poll_seconds * 3)
+        self.lead_minutes = max(0, int(os.getenv("calendar_lead_minutes", "60")))
+        self.exclusive_minutes = max(
+            0, int(os.getenv("calendar_exclusive_minutes", "10"))
+        )
+        self.exclusive_enabled = _enabled("calendar_exclusive_enabled", "true")
+        self.upcoming_priority = int(os.getenv("calendar_priority_upcoming", "40"))
+        self.exclusive_priority = int(os.getenv("calendar_priority_exclusive", "100"))
+        self.agenda_priority = int(os.getenv("calendar_priority_agenda", "20"))
+        self.agenda_interval = max(
+            0, int(os.getenv("calendar_agenda_interval_seconds", "1800"))
+        )
+        self.agenda_duration = max(
+            0, int(os.getenv("calendar_agenda_duration_seconds", "60"))
+        )
+        self.agenda_max_events = max(
+            1, min(4, int(os.getenv("calendar_agenda_max_events", "4")))
+        )
+        self._event_render_key = None
+        self._agenda_render_key = None
+        self._event_was_selected = False
+        self._agenda_was_selected = False
+        self._stop_event = threading.Event()
+        self._thread = None
+
+    def start(self):
+        if not self.enabled or self._thread:
+            return
+        self._thread = threading.Thread(
+            target=self._run,
+            name="CalendarPlugin",
+            daemon=True,
+        )
+        self._thread.start()
+        logger.info("Calendar display plugin started")
+
+    def stop(self):
+        self._stop_event.set()
+        if self._thread:
+            self._thread.join(timeout=1.0)
+        self.arbiter.release(self.EVENT_OWNER)
+        self.arbiter.release(self.AGENDA_OWNER)
+
+    def _run(self):
+        while not self._stop_event.is_set():
+            try:
+                now = datetime.now(self.client.timezone)
+                events = self.client.get_events(now)
+                if self._stop_event.is_set():
+                    break
+                self.tick(now, events)
+            except Exception as exc:
+                logger.error("Calendar plugin update failed (%s)", type(exc).__name__)
+                self.arbiter.release(self.EVENT_OWNER)
+                self.arbiter.release(self.AGENDA_OWNER)
+            self._stop_event.wait(self.poll_seconds)
+
+    def tick(self, now: datetime, events: Iterable[CalendarEvent]):
+        events = sorted(events, key=lambda event: (event.start, event.summary))
+        next_event = next(
+            (event for event in events if not event.all_day and event.start > now),
+            None,
+        )
+        if next_event:
+            seconds_until = (next_event.start - now).total_seconds()
+            if seconds_until <= self.lead_minutes * 60:
+                self._show_event(now, next_event, seconds_until)
+                return
+
+        self.arbiter.release(self.EVENT_OWNER)
+        self._event_was_selected = False
+        self._event_render_key = None
+        self._show_agenda(now, events)
+
+    def _show_event(self, now, event, seconds_until):
+        self.arbiter.release(self.AGENDA_OWNER)
+        self._agenda_was_selected = False
+        exclusive = (
+            self.exclusive_enabled
+            and not event.stale
+            and seconds_until <= self.exclusive_minutes * 60
+        )
+        priority = self.exclusive_priority if exclusive else self.upcoming_priority
+        selected = self.arbiter.claim(
+            self.EVENT_OWNER,
+            priority,
+            self.claim_ttl,
+            exclusive=exclusive,
+        )
+        if not selected:
+            self._event_was_selected = False
+            return
+        minutes = max(0, int((seconds_until + 59) // 60))
+        render_key = (event.uid, exclusive, minutes, event.stale)
+        if render_key == self._event_render_key and self._event_was_selected:
+            return
+        with self.display_lock:
+            if not self.arbiter.can_render(self.EVENT_OWNER):
+                self._event_was_selected = False
+                return
+            draw_upcoming_event(
+                self.epd,
+                event,
+                now,
+                set_base_image=not self._event_was_selected,
+            )
+        self._event_render_key = render_key
+        self._event_was_selected = True
+        if self.on_render:
+            self.on_render(self.EVENT_OWNER)
+
+    def _show_agenda(self, now, events):
+        if not events or not self._agenda_is_due(now):
+            self.arbiter.release(self.AGENDA_OWNER)
+            self._agenda_was_selected = False
+            self._agenda_render_key = None
+            return
+        selected = self.arbiter.claim(
+            self.AGENDA_OWNER,
+            self.agenda_priority,
+            self.claim_ttl,
+        )
+        if not selected:
+            self._agenda_was_selected = False
+            return
+        seconds_since_midnight = now.hour * 3600 + now.minute * 60 + now.second
+        slot = seconds_since_midnight // self.agenda_interval
+        render_key = (
+            slot,
+            tuple(event.uid for event in events[: self.agenda_max_events]),
+        )
+        if render_key == self._agenda_render_key and self._agenda_was_selected:
+            return
+        with self.display_lock:
+            if not self.arbiter.can_render(self.AGENDA_OWNER):
+                self._agenda_was_selected = False
+                return
+            draw_calendar_agenda(
+                self.epd,
+                events[: self.agenda_max_events],
+                now,
+                set_base_image=not self._agenda_was_selected,
+            )
+        self._agenda_render_key = render_key
+        self._agenda_was_selected = True
+        if self.on_render:
+            self.on_render(self.AGENDA_OWNER)
+
+    def _agenda_is_due(self, now):
+        if not self.agenda_interval or not self.agenda_duration:
+            return False
+        seconds_since_midnight = now.hour * 3600 + now.minute * 60 + now.second
+        return seconds_since_midnight % self.agenda_interval < self.agenda_duration

--- a/calendar_service.py
+++ b/calendar_service.py
@@ -272,9 +272,9 @@ class CalendarClient:
                 "Calendar display enabled but no %s sources configured", source_type
             )
         cache_dir = Path(os.getenv("calendar_cache_dir", "cache")).expanduser()
-        timeout = float(os.getenv("calendar_timeout", "10"))
-        max_stale = int(os.getenv("calendar_max_stale_seconds", "21600"))
         try:
+            timeout = float(os.getenv("calendar_timeout", "10"))
+            max_stale = int(os.getenv("calendar_max_stale_seconds", "21600"))
             return [
                 IcsCalendarSource(
                     locator,

--- a/calendar_service.py
+++ b/calendar_service.py
@@ -1,0 +1,330 @@
+"""Read and normalize upcoming events from iCalendar sources."""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import os
+import threading
+import time
+from dataclasses import dataclass, replace
+from datetime import date, datetime, time as datetime_time, timedelta
+from pathlib import Path
+from typing import Iterable, List, Optional
+from zoneinfo import ZoneInfo
+
+import requests
+from ical.calendar_stream import IcsCalendarStream
+
+logger = logging.getLogger(__name__)
+
+
+def _enabled(name: str, default: str = "false") -> bool:
+    return os.getenv(name, default).strip().lower() == "true"
+
+
+def _split_sources(value: str) -> List[str]:
+    return [
+        item.strip() for item in value.replace("\n", ",").split(",") if item.strip()
+    ]
+
+
+@dataclass(frozen=True)
+class CalendarEvent:
+    uid: str
+    summary: str
+    start: datetime
+    end: datetime
+    location: str = ""
+    all_day: bool = False
+    stale: bool = False
+
+
+def _as_datetime(value, timezone: ZoneInfo) -> tuple[datetime, bool]:
+    if isinstance(value, datetime):
+        if value.tzinfo is None:
+            value = value.replace(tzinfo=timezone)
+        return value.astimezone(timezone), False
+    if isinstance(value, date):
+        return datetime.combine(value, datetime_time.min, timezone), True
+    raise ValueError(f"unsupported calendar date value: {value!r}")
+
+
+def parse_ics_events(
+    payload: str,
+    range_start: datetime,
+    range_end: datetime,
+    *,
+    timezone: ZoneInfo,
+    include_all_day: bool,
+    show_details: bool,
+    stale: bool = False,
+) -> List[CalendarEvent]:
+    """Expand and normalize events in an ICS payload for a bounded range."""
+
+    calendar = IcsCalendarStream.calendar_from_ics(payload)
+    events = []
+    for item in calendar.timeline.overlapping(range_start, range_end):
+        status = getattr(item.status, "value", item.status)
+        if str(status or "").upper() == "CANCELLED":
+            continue
+        start, all_day = _as_datetime(item.start, timezone)
+        end, _ = _as_datetime(item.end or item.start, timezone)
+        if (all_day and end <= range_start) or (not all_day and start < range_start):
+            continue
+        if start >= range_end:
+            continue
+        if all_day and not include_all_day:
+            continue
+        summary = str(item.summary or "Untitled event") if show_details else "Busy"
+        location = str(item.location or "") if show_details else ""
+        events.append(
+            CalendarEvent(
+                uid=f"{item.uid or 'event'}:{start.isoformat()}",
+                summary=summary,
+                start=start,
+                end=end,
+                location=location,
+                all_day=all_day,
+                stale=stale,
+            )
+        )
+    return sorted(events, key=lambda event: (event.start, event.end, event.summary))
+
+
+class IcsCalendarSource:
+    """Fetch one HTTP or file ICS source with a private last-good cache."""
+
+    def __init__(
+        self,
+        locator: str,
+        *,
+        source_type: str,
+        cache_dir: Path,
+        timeout: float,
+        max_stale_seconds: int,
+        session=None,
+    ):
+        if source_type not in {"ics", "file"}:
+            raise ValueError(f"unsupported calendar source: {source_type}")
+        self.locator = locator
+        self.source_type = source_type
+        self.timeout = timeout
+        self.max_stale_seconds = max_stale_seconds
+        self.session = session or requests.Session()
+        digest = hashlib.sha256(locator.encode("utf-8")).hexdigest()[:16]
+        self.label = f"{source_type}-{digest}"
+        self.cache_file = cache_dir / f"calendar-{digest}.ics"
+        self._etag = None
+        self._last_modified = None
+        self._payload = None
+        self._pending_etag = None
+        self._pending_last_modified = None
+
+    def events_between(
+        self,
+        range_start: datetime,
+        range_end: datetime,
+        *,
+        timezone: ZoneInfo,
+        include_all_day: bool,
+        show_details: bool,
+    ) -> List[CalendarEvent]:
+        try:
+            payload = self._read_payload()
+            stale = False
+        except Exception as exc:
+            logger.warning(
+                "Calendar source %s unavailable (%s)",
+                self.label,
+                type(exc).__name__,
+            )
+            payload = self._read_cache()
+            stale = True
+        if payload is None:
+            return []
+        try:
+            events = parse_ics_events(
+                payload,
+                range_start,
+                range_end,
+                timezone=timezone,
+                include_all_day=include_all_day,
+                show_details=show_details,
+                stale=stale,
+            )
+        except Exception as exc:
+            logger.warning(
+                "Calendar source %s could not be parsed (%s)",
+                self.label,
+                type(exc).__name__,
+            )
+            if not stale:
+                cached = self._read_cache()
+                if cached is not None and cached != payload:
+                    try:
+                        return parse_ics_events(
+                            cached,
+                            range_start,
+                            range_end,
+                            timezone=timezone,
+                            include_all_day=include_all_day,
+                            show_details=show_details,
+                            stale=True,
+                        )
+                    except Exception:
+                        pass
+            return []
+        if not stale and self.source_type == "ics":
+            self._payload = payload
+            self._etag = self._pending_etag or self._etag
+            self._last_modified = self._pending_last_modified or self._last_modified
+            self._write_cache(payload)
+        return events
+
+    def _read_payload(self) -> str:
+        if self.source_type == "file":
+            return Path(self.locator).expanduser().read_text(encoding="utf-8")
+
+        headers = {
+            "Accept": "text/calendar",
+            "User-Agent": "rpi-waiting-time-display/1",
+        }
+        if self._etag:
+            headers["If-None-Match"] = self._etag
+        if self._last_modified:
+            headers["If-Modified-Since"] = self._last_modified
+        response = self.session.get(
+            self.locator,
+            headers=headers,
+            timeout=self.timeout,
+        )
+        if response.status_code == 304:
+            self._pending_etag = None
+            self._pending_last_modified = None
+            payload = self._payload or self._read_cache(ignore_age=True)
+            if payload is None:
+                raise ValueError("calendar source returned 304 without cached data")
+            return payload
+        response.raise_for_status()
+        payload = response.text
+        self._pending_etag = response.headers.get("ETag")
+        self._pending_last_modified = response.headers.get("Last-Modified")
+        return payload
+
+    def _write_cache(self, payload: str) -> None:
+        try:
+            self.cache_file.parent.mkdir(parents=True, exist_ok=True)
+            temporary = self.cache_file.with_suffix(".tmp")
+            temporary.write_text(payload, encoding="utf-8")
+            temporary.chmod(0o600)
+            temporary.replace(self.cache_file)
+        except OSError as exc:
+            logger.warning(
+                "Could not persist calendar cache %s (%s)",
+                self.label,
+                type(exc).__name__,
+            )
+
+    def _read_cache(self, *, ignore_age: bool = False) -> Optional[str]:
+        try:
+            age = time.time() - self.cache_file.stat().st_mtime
+            if not ignore_age and age > self.max_stale_seconds:
+                return None
+            return self.cache_file.read_text(encoding="utf-8")
+        except OSError:
+            return None
+
+
+class CalendarClient:
+    """Combine configured sources and cache a normalized upcoming event list."""
+
+    def __init__(self, sources: Optional[Iterable[IcsCalendarSource]] = None):
+        self.enabled = _enabled("calendar_enabled")
+        timezone_name = os.getenv("calendar_timezone", "Europe/Brussels").strip()
+        try:
+            self.timezone = ZoneInfo(timezone_name)
+        except (KeyError, ValueError):
+            logger.error("Unknown calendar_timezone %s; using UTC", timezone_name)
+            self.timezone = ZoneInfo("UTC")
+        self.refresh_interval = max(
+            30, int(os.getenv("calendar_refresh_interval", "300"))
+        )
+        self.lookahead_days = max(1, int(os.getenv("calendar_lookahead_days", "3")))
+        self.include_all_day = _enabled("calendar_include_all_day")
+        self.show_details = _enabled("calendar_show_details", "true")
+        self._sources = (
+            list(sources) if sources is not None else self._configured_sources()
+        )
+        self._events: List[CalendarEvent] = []
+        self._last_fetch_monotonic = 0.0
+        self._lock = threading.Lock()
+
+    def _configured_sources(self) -> List[IcsCalendarSource]:
+        source_type = os.getenv("calendar_source", "ics").strip().lower()
+        if source_type == "file":
+            value = os.getenv("calendar_ics_files", os.getenv("calendar_ics_file", ""))
+        else:
+            value = os.getenv("calendar_ics_urls", os.getenv("calendar_ics_url", ""))
+        locators = _split_sources(value)
+        if self.enabled and not locators:
+            logger.error(
+                "Calendar display enabled but no %s sources configured", source_type
+            )
+        cache_dir = Path(os.getenv("calendar_cache_dir", "cache")).expanduser()
+        timeout = float(os.getenv("calendar_timeout", "10"))
+        max_stale = int(os.getenv("calendar_max_stale_seconds", "21600"))
+        try:
+            return [
+                IcsCalendarSource(
+                    locator,
+                    source_type=source_type,
+                    cache_dir=cache_dir,
+                    timeout=timeout,
+                    max_stale_seconds=max_stale,
+                )
+                for locator in locators
+            ]
+        except ValueError as exc:
+            logger.error("Invalid calendar configuration: %s", exc)
+            return []
+
+    def get_events(self, now: Optional[datetime] = None, *, force: bool = False):
+        if not self.enabled:
+            return []
+        now = (now or datetime.now(self.timezone)).astimezone(self.timezone)
+        monotonic_now = time.monotonic()
+        with self._lock:
+            if (
+                force
+                or not self._last_fetch_monotonic
+                or monotonic_now - self._last_fetch_monotonic >= self.refresh_interval
+            ):
+                range_end = now + timedelta(days=self.lookahead_days)
+                fetched = []
+                for source in self._sources:
+                    fetched.extend(
+                        source.events_between(
+                            now,
+                            range_end,
+                            timezone=self.timezone,
+                            include_all_day=self.include_all_day,
+                            show_details=self.show_details,
+                        )
+                    )
+                unique = {}
+                for event in fetched:
+                    key = (event.uid, event.start)
+                    existing = unique.get(key)
+                    if existing is None or (existing.stale and not event.stale):
+                        unique[key] = event
+                self._events = sorted(
+                    unique.values(), key=lambda event: (event.start, event.summary)
+                )
+                self._last_fetch_monotonic = monotonic_now
+            return [
+                replace(event)
+                for event in self._events
+                if (event.all_day and event.end > now)
+                or (not event.all_day and event.start >= now)
+            ]

--- a/docs/calendar-display.md
+++ b/docs/calendar-display.md
@@ -1,0 +1,56 @@
+# Calendar display
+
+The optional calendar plugin reads one or more iCalendar (`.ics`) feeds and
+adds two screen types:
+
+- an event card during the configured lead window (60 minutes by default);
+- a short upcoming-agenda glance every configured interval (one minute every
+  half hour by default).
+
+The final ten minutes before a fresh event are exclusive by default. Earlier
+event cards use priority `40`, so the default flight (`50`) and ISS (`60`)
+claims can temporarily override them. Agenda glances use priority `20` and
+return automatically to the scheduled transit, weather, or token screen.
+
+## Google Calendar setup
+
+Google Calendar does not require an OAuth client for this read-only use case.
+On a computer, open the calendar's settings, choose **Integrate calendar**, and
+copy its **Secret address in iCal format**. Google documents the steps in
+[Sync your calendar with computer programs](https://support.google.com/calendar/answer/37648).
+
+Store the address only in the untracked `.env` file:
+
+```dotenv
+calendar_enabled=true
+calendar_source=ics
+calendar_ics_urls=https://calendar.google.com/calendar/ical/REDACTED/basic.ics
+calendar_timezone=Europe/Brussels
+```
+
+Use a comma-separated `calendar_ics_urls` value for multiple calendars. The
+secret URL is effectively a read-only bearer credential. Never commit it or
+paste it into logs. Reset the secret address in Google Calendar if it is
+exposed. A Workspace administrator may disable secret addresses; in that case
+an authenticated Calendar API or an external bridge such as
+[`gog`](https://github.com/steipete/gogcli) is the fallback, but it requires a
+Google Cloud OAuth client and persistent token/keyring setup.
+
+For development or an externally synchronized feed, use `calendar_source=file`
+with `calendar_ics_file` or comma-separated `calendar_ics_files` paths.
+
+## Refresh and failure behavior
+
+HTTP feeds refresh every five minutes by default and use ETag/Last-Modified
+conditional requests when available. Successful responses are cached under
+`cache/` with owner-only permissions. If a source is temporarily unavailable,
+the plugin may show its last-good events as stale for
+`calendar_max_stale_seconds`, but stale events never receive the exclusive
+pre-event lease.
+
+Cancelled events are ignored. All-day events are excluded by default; when
+enabled, they appear only in the agenda and never take a pre-event lease. Set
+`calendar_show_details=false` to render every item as `Busy` without its
+location.
+
+See `.env.example` for all timing, priority, privacy, and agenda settings.

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -26,6 +26,7 @@ humanize>=4.11.0
 pytest>=8.0.0
 pytest-mock>=3.15.1
 pytest-cov>=4.1.0
+ical>=11.1.0,<12
 responses>=0.24.1
 freezegun>=1.4.0
 black>=24.1.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-# Version: 0.0.22 (2026-03-19) # AUTO-INCREMENT
+# Version: 0.0.23 (2026-07-11) # AUTO-INCREMENT
 # Add this file to pre-commit hook to auto-increment
 
 # Actual requirements below
@@ -63,5 +63,6 @@ cryptography>=46.0.5
 filelock>=3.20.3
 h11>=0.16.0
 pydantic==2.13.3
+ical==11.1.0
 cairosvg==2.9.0
 niquests==3.17.0

--- a/tests/test_calendar_display.py
+++ b/tests/test_calendar_display.py
@@ -1,0 +1,30 @@
+from datetime import datetime, timedelta
+from zoneinfo import ZoneInfo
+
+from PIL import Image
+
+from calendar_display import draw_calendar_agenda, draw_upcoming_event
+from calendar_service import CalendarEvent
+from display_adapter import MockDisplay
+
+
+def test_calendar_views_render_at_display_dimensions(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    timezone = ZoneInfo("Europe/Brussels")
+    now = datetime(2026, 7, 11, 8, 0, tzinfo=timezone)
+    event = CalendarEvent(
+        uid="review",
+        summary="A fairly long team review title that needs wrapping",
+        start=now + timedelta(minutes=10),
+        end=now + timedelta(minutes=40),
+        location="Meeting room 12",
+    )
+    display = MockDisplay()
+
+    draw_upcoming_event(display, event, now, set_base_image=True)
+    upcoming = Image.open("debug_output.png")
+    assert upcoming.size == (display.height, display.width)
+
+    draw_calendar_agenda(display, [event], now, set_base_image=True)
+    agenda = Image.open("debug_output.png")
+    assert agenda.size == (display.height, display.width)

--- a/tests/test_calendar_display.py
+++ b/tests/test_calendar_display.py
@@ -3,7 +3,7 @@ from zoneinfo import ZoneInfo
 
 from PIL import Image
 
-from calendar_display import draw_calendar_agenda, draw_upcoming_event
+from calendar_display import _fonts, draw_calendar_agenda, draw_upcoming_event
 from calendar_service import CalendarEvent
 from display_adapter import MockDisplay
 
@@ -28,3 +28,9 @@ def test_calendar_views_render_at_display_dimensions(monkeypatch, tmp_path):
     draw_calendar_agenda(display, [event], now, set_base_image=True)
     agenda = Image.open("debug_output.png")
     assert agenda.size == (display.height, display.width)
+
+
+def test_calendar_fonts_are_cached():
+    _fonts.cache_clear()
+
+    assert _fonts() is _fonts()

--- a/tests/test_calendar_plugin.py
+++ b/tests/test_calendar_plugin.py
@@ -1,0 +1,135 @@
+import threading
+from datetime import datetime, timedelta
+from types import SimpleNamespace
+from zoneinfo import ZoneInfo
+
+from calendar_plugin import CalendarPlugin
+from calendar_service import CalendarEvent
+from screen_arbiter import ScreenArbiter
+
+TIMEZONE = ZoneInfo("Europe/Brussels")
+
+
+def _event(now, minutes=120, *, stale=False):
+    start = now + timedelta(minutes=minutes)
+    return CalendarEvent(
+        uid=f"event-{minutes}",
+        summary="Team review",
+        start=start,
+        end=start + timedelta(hours=1),
+        location="Room 12",
+        stale=stale,
+    )
+
+
+def _plugin(monkeypatch, rendered):
+    monkeypatch.setenv("calendar_lead_minutes", "60")
+    monkeypatch.setenv("calendar_exclusive_minutes", "10")
+    monkeypatch.setenv("calendar_exclusive_enabled", "true")
+    monkeypatch.setenv("calendar_priority_agenda", "20")
+    monkeypatch.setenv("calendar_priority_upcoming", "40")
+    monkeypatch.setenv("calendar_priority_exclusive", "100")
+    monkeypatch.setenv("calendar_agenda_interval_seconds", "1800")
+    monkeypatch.setenv("calendar_agenda_duration_seconds", "60")
+    monkeypatch.setattr(
+        "calendar_plugin.draw_upcoming_event",
+        lambda *args, **kwargs: rendered.append(("event", kwargs)),
+    )
+    monkeypatch.setattr(
+        "calendar_plugin.draw_calendar_agenda",
+        lambda *args, **kwargs: rendered.append(("agenda", kwargs)),
+    )
+    client = SimpleNamespace(enabled=True, timezone=TIMEZONE)
+    return CalendarPlugin(
+        object(),
+        ScreenArbiter(),
+        threading.Lock(),
+        client=client,
+    )
+
+
+def test_upcoming_event_claim_is_preemptible(monkeypatch):
+    rendered = []
+    plugin = _plugin(monkeypatch, rendered)
+    now = datetime(2026, 7, 11, 8, 5, tzinfo=TIMEZONE)
+
+    plugin.tick(now, [_event(now, 30)])
+
+    claim = plugin.arbiter.claim_for(plugin.EVENT_OWNER)
+    assert claim.priority == 40
+    assert claim.exclusive is False
+    assert plugin.arbiter.claim("flight", 50, 30)
+    assert plugin.arbiter.active_owner() == "flight"
+    assert rendered[0][0] == "event"
+
+
+def test_fresh_event_is_exclusive_in_final_ten_minutes(monkeypatch):
+    rendered = []
+    plugin = _plugin(monkeypatch, rendered)
+    now = datetime(2026, 7, 11, 8, 5, tzinfo=TIMEZONE)
+
+    plugin.tick(now, [_event(now, 5)])
+
+    claim = plugin.arbiter.claim_for(plugin.EVENT_OWNER)
+    assert claim.priority == 100
+    assert claim.exclusive is True
+    assert not plugin.arbiter.claim("flight", 200, 30)
+    assert plugin.arbiter.active_owner() == plugin.EVENT_OWNER
+
+
+def test_stale_event_never_takes_exclusive_control(monkeypatch):
+    rendered = []
+    plugin = _plugin(monkeypatch, rendered)
+    now = datetime(2026, 7, 11, 8, 5, tzinfo=TIMEZONE)
+
+    plugin.tick(now, [_event(now, 5, stale=True)])
+
+    claim = plugin.arbiter.claim_for(plugin.EVENT_OWNER)
+    assert claim.exclusive is False
+    assert plugin.arbiter.claim("flight", 50, 30)
+    assert plugin.arbiter.active_owner() == "flight"
+
+
+def test_agenda_glance_releases_after_configured_minute(monkeypatch):
+    rendered = []
+    plugin = _plugin(monkeypatch, rendered)
+    start = datetime(2026, 7, 11, 8, 0, tzinfo=TIMEZONE)
+    event = _event(start, 120)
+
+    plugin.tick(start, [event])
+    assert plugin.arbiter.active_owner() == plugin.AGENDA_OWNER
+    assert rendered[0][0] == "agenda"
+
+    plugin.tick(start + timedelta(seconds=60), [event])
+    assert plugin.arbiter.active_owner() is None
+
+
+def test_event_start_releases_exclusive_claim(monkeypatch):
+    rendered = []
+    plugin = _plugin(monkeypatch, rendered)
+    now = datetime(2026, 7, 11, 8, 5, tzinfo=TIMEZONE)
+    event = _event(now, 5)
+    plugin.tick(now, [event])
+    assert plugin.arbiter.active_owner() == plugin.EVENT_OWNER
+
+    plugin.tick(event.start, [event])
+
+    assert plugin.arbiter.active_owner() is None
+
+
+def test_all_day_event_only_appears_in_agenda(monkeypatch):
+    rendered = []
+    plugin = _plugin(monkeypatch, rendered)
+    now = datetime(2026, 7, 11, 8, 0, tzinfo=TIMEZONE)
+    event = CalendarEvent(
+        uid="all-day",
+        summary="Birthday",
+        start=now + timedelta(minutes=5),
+        end=now + timedelta(days=1),
+        all_day=True,
+    )
+
+    plugin.tick(now, [event])
+
+    assert plugin.arbiter.active_owner() == plugin.AGENDA_OWNER
+    assert rendered[0][0] == "agenda"

--- a/tests/test_calendar_service.py
+++ b/tests/test_calendar_service.py
@@ -237,3 +237,15 @@ def test_calendar_client_reads_configured_file_source(tmp_path, monkeypatch):
     events = CalendarClient().get_events(NOW, force=True)
 
     assert [event.start.day for event in events] == [13, 20]
+
+
+def test_invalid_source_timeout_does_not_crash_startup(monkeypatch, caplog):
+    monkeypatch.setenv("calendar_enabled", "true")
+    monkeypatch.setenv("calendar_source", "ics")
+    monkeypatch.setenv("calendar_ics_url", "https://calendar.example/basic.ics")
+    monkeypatch.setenv("calendar_timeout", "not-a-number")
+
+    client = CalendarClient()
+
+    assert client._sources == []
+    assert "Invalid calendar configuration" in caplog.text

--- a/tests/test_calendar_service.py
+++ b/tests/test_calendar_service.py
@@ -1,0 +1,239 @@
+import stat
+from datetime import datetime, timedelta
+from pathlib import Path
+from zoneinfo import ZoneInfo
+
+import requests
+
+from calendar_service import CalendarClient, IcsCalendarSource, parse_ics_events
+
+TIMEZONE = ZoneInfo("Europe/Brussels")
+NOW = datetime(2026, 7, 11, 8, 0, tzinfo=TIMEZONE)
+ICS = """BEGIN:VCALENDAR
+VERSION:2.0
+BEGIN:VEVENT
+UID:standup
+DTSTART;TZID=Europe/Brussels:20260706T100000
+DTEND;TZID=Europe/Brussels:20260706T103000
+RRULE:FREQ=WEEKLY;COUNT=4
+SUMMARY:Weekly standup
+LOCATION:Room 12
+END:VEVENT
+BEGIN:VEVENT
+UID:all-day
+DTSTART;VALUE=DATE:20260711
+DTEND;VALUE=DATE:20260712
+SUMMARY:Birthday
+END:VEVENT
+BEGIN:VEVENT
+UID:cancelled
+DTSTART;TZID=Europe/Brussels:20260712T120000
+DTEND;TZID=Europe/Brussels:20260712T130000
+SUMMARY:Cancelled meeting
+STATUS:CANCELLED
+END:VEVENT
+END:VCALENDAR
+"""
+
+
+class FakeResponse:
+    def __init__(self, status_code, text="", headers=None):
+        self.status_code = status_code
+        self.text = text
+        self.headers = headers or {}
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise requests.HTTPError(f"HTTP {self.status_code}")
+
+
+class FakeSession:
+    def __init__(self, responses):
+        self.responses = iter(responses)
+        self.calls = []
+
+    def get(self, url, **kwargs):
+        self.calls.append((url, kwargs))
+        response = next(self.responses)
+        if isinstance(response, Exception):
+            raise response
+        return response
+
+
+def test_parser_expands_recurring_events_and_skips_cancelled():
+    events = parse_ics_events(
+        ICS,
+        NOW,
+        NOW + timedelta(days=12),
+        timezone=TIMEZONE,
+        include_all_day=False,
+        show_details=True,
+    )
+
+    assert [event.start.day for event in events] == [13, 20]
+    assert all(event.summary == "Weekly standup" for event in events)
+    assert all(event.location == "Room 12" for event in events)
+
+
+def test_parser_can_include_current_all_day_events_and_hide_details():
+    events = parse_ics_events(
+        ICS,
+        NOW,
+        NOW + timedelta(days=2),
+        timezone=TIMEZONE,
+        include_all_day=True,
+        show_details=False,
+    )
+
+    assert len(events) == 1
+    assert events[0].all_day is True
+    assert events[0].summary == "Busy"
+    assert events[0].location == ""
+
+
+def test_http_source_uses_conditional_requests_and_private_cache(tmp_path):
+    session = FakeSession(
+        [
+            FakeResponse(200, ICS, {"ETag": '"v1"'}),
+            FakeResponse(304),
+        ]
+    )
+    source = IcsCalendarSource(
+        "https://calendar.example/secret/basic.ics",
+        source_type="ics",
+        cache_dir=tmp_path,
+        timeout=5,
+        max_stale_seconds=3600,
+        session=session,
+    )
+
+    first = source.events_between(
+        NOW,
+        NOW + timedelta(days=12),
+        timezone=TIMEZONE,
+        include_all_day=False,
+        show_details=True,
+    )
+    second = source.events_between(
+        NOW,
+        NOW + timedelta(days=12),
+        timezone=TIMEZONE,
+        include_all_day=False,
+        show_details=True,
+    )
+
+    assert len(first) == len(second) == 2
+    assert session.calls[1][1]["headers"]["If-None-Match"] == '"v1"'
+    assert stat.S_IMODE(source.cache_file.stat().st_mode) == 0o600
+
+
+def test_http_failure_uses_stale_cache_without_logging_secret(tmp_path, caplog):
+    locator = "https://calendar.example/very-secret/basic.ics"
+    successful = IcsCalendarSource(
+        locator,
+        source_type="ics",
+        cache_dir=tmp_path,
+        timeout=5,
+        max_stale_seconds=3600,
+        session=FakeSession([FakeResponse(200, ICS)]),
+    )
+    successful.events_between(
+        NOW,
+        NOW + timedelta(days=12),
+        timezone=TIMEZONE,
+        include_all_day=False,
+        show_details=True,
+    )
+    failing = IcsCalendarSource(
+        locator,
+        source_type="ics",
+        cache_dir=tmp_path,
+        timeout=5,
+        max_stale_seconds=3600,
+        session=FakeSession([requests.ConnectionError("offline")]),
+    )
+
+    events = failing.events_between(
+        NOW,
+        NOW + timedelta(days=12),
+        timezone=TIMEZONE,
+        include_all_day=False,
+        show_details=True,
+    )
+
+    assert len(events) == 2
+    assert all(event.stale for event in events)
+    assert "very-secret" not in caplog.text
+
+
+def test_malformed_http_response_does_not_replace_last_good_cache(tmp_path):
+    locator = "https://calendar.example/secret/basic.ics"
+    source = IcsCalendarSource(
+        locator,
+        source_type="ics",
+        cache_dir=tmp_path,
+        timeout=5,
+        max_stale_seconds=3600,
+        session=FakeSession(
+            [
+                FakeResponse(200, ICS, {"ETag": '"v1"'}),
+                FakeResponse(200, "not a calendar", {"ETag": '"broken"'}),
+            ]
+        ),
+    )
+    source.events_between(
+        NOW,
+        NOW + timedelta(days=12),
+        timezone=TIMEZONE,
+        include_all_day=False,
+        show_details=True,
+    )
+
+    events = source.events_between(
+        NOW,
+        NOW + timedelta(days=12),
+        timezone=TIMEZONE,
+        include_all_day=False,
+        show_details=True,
+    )
+
+    assert len(events) == 2
+    assert all(event.stale for event in events)
+    assert source.cache_file.read_text(encoding="utf-8") == ICS
+
+
+def test_file_source_reads_local_ics(tmp_path):
+    path = tmp_path / "calendar.ics"
+    path.write_text(ICS, encoding="utf-8")
+    source = IcsCalendarSource(
+        str(path),
+        source_type="file",
+        cache_dir=Path(tmp_path),
+        timeout=5,
+        max_stale_seconds=3600,
+    )
+
+    events = source.events_between(
+        NOW,
+        NOW + timedelta(days=12),
+        timezone=TIMEZONE,
+        include_all_day=False,
+        show_details=True,
+    )
+
+    assert len(events) == 2
+    assert all(not event.stale for event in events)
+
+
+def test_calendar_client_reads_configured_file_source(tmp_path, monkeypatch):
+    path = tmp_path / "calendar.ics"
+    path.write_text(ICS, encoding="utf-8")
+    monkeypatch.setenv("calendar_enabled", "true")
+    monkeypatch.setenv("calendar_source", "file")
+    monkeypatch.setenv("calendar_ics_file", str(path))
+    monkeypatch.setenv("calendar_timezone", "Europe/Brussels")
+    monkeypatch.setenv("calendar_lookahead_days", "12")
+
+    events = CalendarClient().get_events(NOW, force=True)
+
+    assert [event.start.day for event in events] == [13, 20]


### PR DESCRIPTION
## Dependency

The shared screen arbiter from #113 is merged into `main`.

## What changed

- add HTTP and file iCalendar sources with recurring-event expansion and timezone normalization
- support multiple Google Calendar secret ICS feeds without OAuth credentials on the display
- use conditional HTTP requests and a private last-good cache without logging feed URLs
- refuse exclusive control for stale cached events
- add a pre-event card and a four-row upcoming-agenda view for the 250×120 e-paper layout
- claim the screen non-exclusively during the configurable lead window and exclusively for the final ten minutes by default
- show a one-minute agenda glance every half hour by default, then return to the scheduled base screen
- expose source, privacy, timing, duration, priority, and all-day settings in `.env.example`

## Why ICS instead of gog/API

Google Calendar exposes a read-only Secret address in iCal format for calendars whose sharing policy permits it. This avoids setting up a Google Cloud OAuth client and persistent refresh-token/keyring storage on the Raspberry Pi. The module keeps the source abstraction narrow so an authenticated API bridge can be added later if a Workspace administrator disables secret ICS addresses.

## Privacy and failure behavior

The secret URL remains in the ignored `.env`. Cache filenames contain only a SHA-256-derived identifier, cache files are owner-readable only, request errors do not log the URL, malformed HTTP responses do not replace the last-good cache, and stale events can never acquire the exclusive lease.

## Validation

- `212 passed` with the full pytest suite
- recurrence, cancellation, all-day, privacy, multi-source client, ETag, cache, malformed-response, stale-safety, priority, exclusivity, agenda-return, configuration-failure, font-cache, and renderer tests
- visual QA of both 250×120 calendar screens with `MockDisplay`
- Black and Flake8 checks on all new Python files
- `git diff --check`
