### PR TITLE
Add arbitrated RSS and Nitter watch display

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -124,6 +124,20 @@ calendar_agenda_interval_seconds=1800
 calendar_agenda_duration_seconds=60
 calendar_agenda_max_events=4
 
+# Optional RSS/Nitter watcher. The first poll establishes a baseline, so old
+# feed entries are not displayed. Keep private feed URLs in the ignored .env.
+rss_watch_enabled=false
+rss_nitter_base_url=http://nitter.local
+rss_nitter_users=
+rss_feed_urls=
+rss_watch_poll_seconds=60
+rss_watch_display_seconds=60
+rss_watch_priority=30
+rss_watch_max_queue=10
+rss_watch_timeout=10
+rss_watch_state_file=cache/rss-watch-state.json
+rss_watch_show_existing=false
+
 # Weather settings
 WEATHER_PROVIDER=openmeteo  # openmeteo or openweather
 OPENWEATHER_API_KEY=  # Only needed if using openweather provider

--- a/.env.example
+++ b/.env.example
@@ -129,6 +129,8 @@ calendar_agenda_max_events=4
 rss_watch_enabled=false
 rss_nitter_base_url=http://nitter.local
 rss_nitter_users=
+# Use /{handle}/with_replies/rss to include replies as well as original posts.
+rss_nitter_feed_path=/{handle}/rss
 rss_feed_urls=
 rss_watch_poll_seconds=60
 rss_watch_display_seconds=60

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -123,6 +123,18 @@ Key environment variables:
 - Use step-by-step approach for new features
 - Create GitHub issues for bugs that can't be fixed quickly
 
+## Pull request follow-through
+
+- Opening a pull request is not the end of the task. Wait for configured CI and
+  review bots to finish, inspect their feedback, and implement valid fixes before
+  reporting the PR as ready or the task as complete.
+- Re-run the relevant tests after review fixes and confirm that required checks
+  are green and actionable review threads are resolved.
+- Merge only when the user's request or standing instructions authorize merging.
+  If the request was only to create a PR, hand the clean PR back to the user for
+  confirmation instead. If merging is authorized, merge once the PR is clean and
+  report the resulting merge commit.
+
 ## Deployment and privacy
 
 - The public Git repository is the source of truth for application code. Keep hostnames, IP addresses, bearer tokens, account identifiers, usage snapshots, and personal `.env` values out of tracked files and commit history.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,6 +76,7 @@ python webserial_server.py
 - **webserial_server.py**: Web-based setup interface
 - **token_usage.py**: Optional schedule parser and normalized token-usage client
 - **token_display.py**: Compact month-to-date and rate-limit e-paper views
+- **rss_service.py**, **rss_plugin.py**: RSS/Nitter polling and arbitrated notifications
 - **tools/token_usage_server.py**: Authenticated bridge for a remote usage source
 
 ### Key Design Patterns

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -123,18 +123,6 @@ Key environment variables:
 - Use step-by-step approach for new features
 - Create GitHub issues for bugs that can't be fixed quickly
 
-## Pull request follow-through
-
-- Opening a pull request is not the end of the task. Wait for configured CI and
-  review bots to finish, inspect their feedback, and implement valid fixes before
-  reporting the PR as ready or the task as complete.
-- Re-run the relevant tests after review fixes and confirm that required checks
-  are green and actionable review threads are resolved.
-- Merge only when the user's request or standing instructions authorize merging.
-  If the request was only to create a PR, hand the clean PR back to the user for
-  confirmation instead. If merging is authorized, merge once the PR is clean and
-  report the resulting merge commit.
-
 ## Deployment and privacy
 
 - The public Git repository is the source of truth for application code. Keep hostnames, IP addresses, bearer tokens, account identifiers, usage snapshots, and personal `.env` values out of tracked files and commit history.

--- a/basic.py
+++ b/basic.py
@@ -29,6 +29,7 @@ from token_usage import (
     token_view_at,
 )
 from screen_arbiter import ScreenArbiter
+from rss_plugin import RSSPlugin
 from calendar_plugin import CalendarPlugin
 
 logger = logging.getLogger(__name__)
@@ -326,6 +327,12 @@ class DisplayManager:
             self._display_lock,
             on_render=self._calendar_rendered,
         )
+        self.rss_plugin = RSSPlugin(
+            epd,
+            self.screen_arbiter,
+            self._display_lock,
+            on_render=self._plugin_rendered,
+        )
         logger.info(f"DisplayManager initialized with min refresh interval: {self.min_refresh_interval}s")
         logger.info(f"DisplayManager initialized with coordinates: {self.coordinates_lat}, {self.coordinates_lng}")
         logger.info(f"DisplayManager initialized with flight mode duration: {self.flight_mode_duration}s")
@@ -338,6 +345,9 @@ class DisplayManager:
             logger.info("Token usage display enabled with views: %s", ", ".join(self.token_views))
 
     def _calendar_rendered(self, owner):
+        self._plugin_rendered(owner)
+
+    def _plugin_rendered(self, owner):
         self.current_display_mode = owner
         self.current_token_view = None
         self.in_weather_mode = False
@@ -405,6 +415,7 @@ class DisplayManager:
         # Calendar events are fetched and rendered independently of the base
         # transit/weather/token data sources.
         self.calendar_plugin.start()
+        self.rss_plugin.start()
         
         # Token views do not depend on transit either. The normal update loop
         # will prefetch it when a transit or automatic window becomes active.
@@ -879,6 +890,7 @@ class DisplayManager:
             self.iss_tracker.stop()
 
         self.calendar_plugin.stop()
+        self.rss_plugin.stop()
             
         for thread in [self._check_data_thread, self._flight_thread, self._iss_thread]:
             if thread:

--- a/docs/rss-watch-display.md
+++ b/docs/rss-watch-display.md
@@ -16,8 +16,12 @@ remains the source of truth, while the display is a readable notification.
 rss_watch_enabled=true
 rss_nitter_base_url=http://your-nitter-instance
 rss_nitter_users=account_one,account_two
+rss_nitter_feed_path=/{handle}/rss
 rss_feed_urls=https://example.org/feed.xml,https://example.net/atom.xml
 ```
+
+Set `rss_nitter_feed_path=/{handle}/with_replies/rss` when the source watchlist
+includes replies. `{handle}` is replaced with each safely encoded username.
 
 The first successful poll records a baseline and does not display old entries.
 State is retained in `cache/rss-watch-state.json`, so restarts do not replay

--- a/docs/rss-watch-display.md
+++ b/docs/rss-watch-display.md
@@ -1,0 +1,32 @@
+# RSS watch display
+
+The optional RSS watcher polls standard RSS or Atom feeds and briefly displays
+new entries through the shared screen arbiter. It supports two layouts:
+
+- Nitter feeds show the author, `@handle`, tweet text, and the feed avatar when
+  one is advertised by the channel.
+- Other feeds show the publication and post title, with an author when present.
+
+The 250x120 layout deliberately omits URLs and article summaries. The feed URL
+remains the source of truth, while the display is a readable notification.
+
+## Configuration
+
+```dotenv
+rss_watch_enabled=true
+rss_nitter_base_url=http://your-nitter-instance
+rss_nitter_users=account_one,account_two
+rss_feed_urls=https://example.org/feed.xml,https://example.net/atom.xml
+```
+
+The first successful poll records a baseline and does not display old entries.
+State is retained in `cache/rss-watch-state.json`, so restarts do not replay
+posts. Set `rss_watch_show_existing=true` only when testing the layout.
+
+Each entry claims the screen for `rss_watch_display_seconds` (60 by default) at
+priority `rss_watch_priority` (30 by default). A higher-priority arbiter claim
+can override it. Up to `rss_watch_max_queue` entries are shown in chronological
+order; older excess notifications are discarded.
+
+Feed requests use `rss_watch_timeout`. Feed credentials and private hostnames
+belong only in the ignored `.env`, never in tracked configuration.

--- a/docs/screen-arbiter.md
+++ b/docs/screen-arbiter.md
@@ -33,3 +33,7 @@ Flights default to priority `50`. ISS defaults to `60` when the existing
 
 Future plugins should use bounded claims and check `can_render(owner)` again
 while holding the display lock immediately before writing to the device.
+
+The RSS watcher defaults to priority `30`: it interrupts the scheduled base
+screen and calendar agenda glances, but yields to upcoming calendar events,
+flights, and the priority ISS view. Set `rss_watch_priority` to change this.

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,5 +1,6 @@
 #As certain packages don't seem to work, these ones should be available in a dev environment on a Mac
 certifi>=2024.12.14
+defusedxml>=0.7.1
 charset-normalizer>=3.4.7
 colorzero>=2.0
 gpiozero>=2.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-# Version: 0.0.23 (2026-07-11) # AUTO-INCREMENT
+# Version: 0.0.24 (2026-07-11) # AUTO-INCREMENT
 # Add this file to pre-commit hook to auto-increment
 
 # Actual requirements below
@@ -66,3 +66,4 @@ pydantic==2.13.3
 ical==11.1.0
 cairosvg==2.9.0
 niquests==3.17.0
+defusedxml==0.7.1

--- a/rss_display.py
+++ b/rss_display.py
@@ -1,0 +1,130 @@
+"""Compact RSS and Nitter cards for a 250x120 e-paper canvas."""
+
+from __future__ import annotations
+
+import io
+import os
+from functools import lru_cache
+
+from PIL import Image, ImageDraw, ImageFont, ImageOps
+
+from display_adapter import return_display_lock
+from font_utils import get_font_paths
+
+display_lock = return_display_lock()
+DISPLAY_SCREEN_ROTATION = int(os.getenv("screen_rotation", "90"))
+
+
+@lru_cache(maxsize=1)
+def _fonts():
+    paths = get_font_paths()
+    try:
+        return (
+            ImageFont.truetype(paths["dejavu_bold"], 12),
+            ImageFont.truetype(paths["dejavu_bold"], 14),
+            ImageFont.truetype(paths["dejavu"], 11),
+            ImageFont.truetype(paths["dejavu"], 9),
+        )
+    except OSError:
+        fallback = ImageFont.load_default()
+        return fallback, fallback, fallback, fallback
+
+
+def _ellipsize(draw, text, font, width):
+    text = " ".join(text.split())
+    if draw.textbbox((0, 0), text, font=font)[2] <= width:
+        return text
+    while text and draw.textbbox((0, 0), text + "…", font=font)[2] > width:
+        text = text[:-1]
+    return text.rstrip() + "…"
+
+
+def _wrap(draw, text, font, width, lines):
+    words = " ".join(text.split()).split()
+    output = []
+    while words and len(output) < lines:
+        line = ""
+        while words:
+            candidate = f"{line} {words[0]}".strip()
+            if line and draw.textbbox((0, 0), candidate, font=font)[2] > width:
+                break
+            line = candidate
+            words.pop(0)
+        if len(output) == lines - 1 and words:
+            line = _ellipsize(draw, f"{line} {' '.join(words)}", font, width)
+            words.clear()
+        output.append(line)
+    return output
+
+
+def _finish(epd, image, set_base_image):
+    image = image.rotate(DISPLAY_SCREEN_ROTATION, expand=True)
+    with display_lock:
+        buffer = epd.getbuffer(image)
+        if hasattr(epd, "displayPartial"):
+            if set_base_image and hasattr(epd, "displayPartBaseImage"):
+                epd.init()
+                epd.displayPartBaseImage(buffer)
+            else:
+                epd.displayPartial(buffer)
+        else:
+            epd.display(buffer)
+
+
+def draw_feed_entry(epd, entry, *, avatar_bytes=None, set_base_image=False):
+    white = epd.WHITE if not epd.is_bw_display else 1
+    black = epd.BLACK if not epd.is_bw_display else 0
+    image = Image.new(
+        "1" if epd.is_bw_display else "RGB", (epd.height, epd.width), white
+    )
+    draw = ImageDraw.Draw(image)
+    header, title_font, body_font, tiny = _fonts()
+    is_tweet = entry.kind == "nitter"
+    label = (
+        "NEW POST"
+        if is_tweet
+        else _ellipsize(draw, entry.publication.upper(), header, 180)
+    )
+    draw.text((7, 5), label, font=header, fill=black)
+    time_label = (
+        entry.published.astimezone().strftime("%H:%M") if entry.published else "RSS"
+    )
+    time_width = draw.textbbox((0, 0), time_label, font=tiny)[2]
+    draw.text((243 - time_width, 7), time_label, font=tiny, fill=black)
+    draw.line((7, 23, 243, 23), fill=black, width=1)
+
+    left = 7
+    if is_tweet and avatar_bytes:
+        try:
+            avatar = Image.open(io.BytesIO(avatar_bytes)).convert("L")
+            avatar = ImageOps.fit(avatar, (38, 38)).convert(image.mode)
+            image.paste(avatar, (7, 30))
+            left = 52
+        except (OSError, ValueError):
+            pass
+    if is_tweet:
+        author = entry.author or entry.publication
+        identity = f"{author}  {entry.handle}".strip()
+        draw.text(
+            (left, 29),
+            _ellipsize(draw, identity, title_font, 243 - left),
+            font=title_font,
+            fill=black,
+        )
+        y, max_lines = 48, 4
+        width = 243 - left if left > 7 else 236
+        for index, line in enumerate(
+            _wrap(draw, entry.title, body_font, width, max_lines)
+        ):
+            draw.text((left, y + index * 14), line, font=body_font, fill=black)
+    else:
+        for index, line in enumerate(_wrap(draw, entry.title, title_font, 236, 4)):
+            draw.text((7, 31 + index * 18), line, font=title_font, fill=black)
+        if entry.author:
+            draw.text(
+                (7, 104),
+                _ellipsize(draw, entry.author, tiny, 236),
+                font=tiny,
+                fill=black,
+            )
+    _finish(epd, image, set_base_image)

--- a/rss_plugin.py
+++ b/rss_plugin.py
@@ -3,13 +3,12 @@
 from __future__ import annotations
 
 import logging
-import os
 import threading
 import time
 from collections import deque
 
 from rss_display import draw_feed_entry
-from rss_service import RSSWatcher
+from rss_service import RSSWatcher, env_int
 
 logger = logging.getLogger(__name__)
 
@@ -27,10 +26,10 @@ class RSSPlugin:
         self.on_render = on_render
         self.clock = clock or time.monotonic
         self.enabled = self.watcher.enabled
-        self.poll_seconds = max(15, int(os.getenv("rss_watch_poll_seconds", "60")))
-        self.duration = max(5, int(os.getenv("rss_watch_display_seconds", "60")))
-        self.priority = int(os.getenv("rss_watch_priority", "30"))
-        self.max_queue = max(1, int(os.getenv("rss_watch_max_queue", "10")))
+        self.poll_seconds = max(15, env_int("rss_watch_poll_seconds", 60))
+        self.duration = max(5, env_int("rss_watch_display_seconds", 60))
+        self.priority = env_int("rss_watch_priority", 30)
+        self.max_queue = max(1, env_int("rss_watch_max_queue", 10))
         self._queue = deque()
         self._active_until = None
         self._rendered_key = None
@@ -60,7 +59,8 @@ class RSSPlugin:
                 except Exception as exc:
                     logger.warning("RSS watcher update failed (%s)", type(exc).__name__)
                 next_poll = now + self.poll_seconds
-            self.tick(now)
+            if not self._stop_event.is_set():
+                self.tick(now)
             self._stop_event.wait(1.0)
 
     def add_entries(self, entries):
@@ -95,11 +95,18 @@ class RSSPlugin:
         if entry.avatar_url:
             try:
                 response = self.watcher.session.get(
-                    entry.avatar_url, timeout=self.watcher.timeout
+                    entry.avatar_url,
+                    timeout=self.watcher.timeout,
+                    stream=True,
                 )
                 response.raise_for_status()
-                if len(response.content) <= 512_000:
-                    avatar = response.content
+                content = bytearray()
+                for chunk in response.iter_content(chunk_size=16_384):
+                    content.extend(chunk)
+                    if len(content) > 512_000:
+                        break
+                else:
+                    avatar = bytes(content)
             except Exception:
                 logger.debug("RSS avatar unavailable", exc_info=True)
         with self.display_lock:

--- a/rss_plugin.py
+++ b/rss_plugin.py
@@ -113,6 +113,6 @@ class RSSPlugin:
             if not self.arbiter.can_render(self.OWNER):
                 return
             draw_feed_entry(self.epd, entry, avatar_bytes=avatar, set_base_image=True)
-        self._rendered_key = entry.key
-        if self.on_render:
-            self.on_render(self.OWNER)
+            self._rendered_key = entry.key
+            if self.on_render:
+                self.on_render(self.OWNER)

--- a/rss_plugin.py
+++ b/rss_plugin.py
@@ -1,0 +1,111 @@
+"""RSS watcher display plugin backed by the shared screen arbiter."""
+
+from __future__ import annotations
+
+import logging
+import os
+import threading
+import time
+from collections import deque
+
+from rss_display import draw_feed_entry
+from rss_service import RSSWatcher
+
+logger = logging.getLogger(__name__)
+
+
+class RSSPlugin:
+    OWNER = "rss-watch"
+
+    def __init__(
+        self, epd, arbiter, display_lock, *, watcher=None, on_render=None, clock=None
+    ):
+        self.epd = epd
+        self.arbiter = arbiter
+        self.display_lock = display_lock
+        self.watcher = watcher or RSSWatcher()
+        self.on_render = on_render
+        self.clock = clock or time.monotonic
+        self.enabled = self.watcher.enabled
+        self.poll_seconds = max(15, int(os.getenv("rss_watch_poll_seconds", "60")))
+        self.duration = max(5, int(os.getenv("rss_watch_display_seconds", "60")))
+        self.priority = int(os.getenv("rss_watch_priority", "30"))
+        self.max_queue = max(1, int(os.getenv("rss_watch_max_queue", "10")))
+        self._queue = deque()
+        self._active_until = None
+        self._rendered_key = None
+        self._thread = None
+        self._stop_event = threading.Event()
+
+    def start(self):
+        if not self.enabled or self._thread:
+            return
+        self._thread = threading.Thread(target=self._run, name="RSSPlugin", daemon=True)
+        self._thread.start()
+        logger.info("RSS watcher started for %d feeds", len(self.watcher.sources))
+
+    def stop(self):
+        self._stop_event.set()
+        if self._thread:
+            self._thread.join(timeout=1.0)
+        self.arbiter.release(self.OWNER)
+
+    def _run(self):
+        next_poll = 0.0
+        while not self._stop_event.is_set():
+            now = self.clock()
+            if now >= next_poll:
+                try:
+                    self.add_entries(self.watcher.poll())
+                except Exception as exc:
+                    logger.warning("RSS watcher update failed (%s)", type(exc).__name__)
+                next_poll = now + self.poll_seconds
+            self.tick(now)
+            self._stop_event.wait(1.0)
+
+    def add_entries(self, entries):
+        known = {entry.key for entry in self._queue}
+        for entry in entries:
+            if entry.key not in known:
+                self._queue.append(entry)
+                known.add(entry.key)
+        while len(self._queue) > self.max_queue:
+            self._queue.popleft()
+
+    def tick(self, now=None):
+        now = self.clock() if now is None else now
+        if self._active_until is not None and now >= self._active_until:
+            if self._queue:
+                self._queue.popleft()
+            self._active_until = None
+            self._rendered_key = None
+            self.arbiter.release(self.OWNER)
+        if not self._queue:
+            self.arbiter.release(self.OWNER)
+            return
+        if self._active_until is None:
+            self._active_until = now + self.duration
+        remaining = max(1, self._active_until - now)
+        if not self.arbiter.claim(self.OWNER, self.priority, remaining):
+            return
+        entry = self._queue[0]
+        if entry.key == self._rendered_key:
+            return
+        avatar = None
+        if entry.avatar_url:
+            try:
+                response = self.watcher.session.get(
+                    entry.avatar_url, timeout=self.watcher.timeout
+                )
+                response.raise_for_status()
+                if len(response.content) <= 512_000:
+                    avatar = response.content
+            except Exception:
+                logger.debug("RSS avatar unavailable", exc_info=True)
+        with self.display_lock:
+            if not self.arbiter.can_render(self.OWNER):
+                return
+            draw_feed_entry(self.epd, entry, avatar_bytes=avatar, set_base_image=True)
+        self._rendered_key = entry.key
+        if self.on_render:
+            self.on_render(self.OWNER)

--- a/rss_service.py
+++ b/rss_service.py
@@ -22,6 +22,15 @@ import requests
 logger = logging.getLogger(__name__)
 
 
+def env_int(name: str, default: int) -> int:
+    value = os.getenv(name, "").strip()
+    try:
+        return int(value) if value else default
+    except ValueError:
+        logger.warning("Invalid %s value; using %s", name, default)
+        return default
+
+
 class _TextExtractor(HTMLParser):
     def __init__(self):
         super().__init__()
@@ -170,7 +179,7 @@ class RSSWatcher:
         self.enabled = os.getenv(
             "rss_watch_enabled", "false"
         ).lower() == "true" and bool(self.sources)
-        self.timeout = max(1, int(os.getenv("rss_watch_timeout", "10")))
+        self.timeout = max(1, env_int("rss_watch_timeout", 10))
         self.show_existing = (
             os.getenv("rss_watch_show_existing", "false").lower() == "true"
         )
@@ -182,7 +191,7 @@ class RSSWatcher:
 
     def _load_state(self):
         try:
-            data = json.loads(self.state_path.read_text())
+            data = json.loads(self.state_path.read_text(encoding="utf-8"))
             return {url: list(keys) for url, keys in data.get("seen", {}).items()}
         except (OSError, ValueError, TypeError):
             return {}
@@ -194,7 +203,7 @@ class RSSWatcher:
             dir=self.state_path.parent, prefix=".rss-state-"
         )
         try:
-            with os.fdopen(fd, "w") as handle:
+            with os.fdopen(fd, "w", encoding="utf-8") as handle:
                 handle.write(payload)
             os.replace(temporary, self.state_path)
         finally:

--- a/rss_service.py
+++ b/rss_service.py
@@ -1,0 +1,230 @@
+"""Small, dependency-free RSS/Atom watcher used by the display plugin."""
+
+from __future__ import annotations
+
+import hashlib
+import html
+import json
+import logging
+import os
+import tempfile
+import xml.etree.ElementTree as ET
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from email.utils import parsedate_to_datetime
+from html.parser import HTMLParser
+from pathlib import Path
+from typing import Iterable, Optional
+from urllib.parse import urljoin
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+
+class _TextExtractor(HTMLParser):
+    def __init__(self):
+        super().__init__()
+        self.parts = []
+
+    def handle_data(self, data):
+        self.parts.append(data)
+
+
+def clean_text(value: str) -> str:
+    parser = _TextExtractor()
+    try:
+        parser.feed(html.unescape(value or ""))
+        value = " ".join(parser.parts)
+    except Exception:
+        value = value or ""
+    return " ".join(value.split())
+
+
+def _local_name(tag: str) -> str:
+    return tag.rsplit("}", 1)[-1].lower()
+
+
+def _child(element, *names):
+    names = {name.lower() for name in names}
+    return next((child for child in element if _local_name(child.tag) in names), None)
+
+
+def _text(element, *names) -> str:
+    child = _child(element, *names)
+    return "" if child is None else "".join(child.itertext()).strip()
+
+
+def _parse_date(value: str) -> Optional[datetime]:
+    if not value:
+        return None
+    try:
+        parsed = parsedate_to_datetime(value)
+    except (TypeError, ValueError, OverflowError):
+        try:
+            parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        except ValueError:
+            return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed
+
+
+@dataclass(frozen=True)
+class FeedSource:
+    url: str
+    kind: str = "rss"
+    label: str = ""
+    handle: str = ""
+
+
+@dataclass(frozen=True)
+class FeedEntry:
+    key: str
+    source_url: str
+    kind: str
+    publication: str
+    title: str
+    link: str = ""
+    author: str = ""
+    handle: str = ""
+    avatar_url: str = ""
+    published: Optional[datetime] = None
+
+
+def configured_sources() -> list[FeedSource]:
+    sources = []
+    nitter_base = os.getenv("rss_nitter_base_url", "").strip().rstrip("/")
+    for handle in os.getenv("rss_nitter_users", "").split(","):
+        handle = handle.strip().lstrip("@")
+        if handle and nitter_base:
+            sources.append(
+                FeedSource(
+                    f"{nitter_base}/{handle}/rss",
+                    kind="nitter",
+                    handle=f"@{handle}",
+                )
+            )
+    for url in os.getenv("rss_feed_urls", "").split(","):
+        if url.strip():
+            sources.append(FeedSource(url.strip()))
+    return sources
+
+
+def parse_feed(content: bytes, source: FeedSource) -> list[FeedEntry]:
+    root = ET.fromstring(content)
+    channel_element = _child(root, "channel")
+    channel = channel_element if channel_element is not None else root
+    publication = source.label or clean_text(_text(channel, "title")) or "RSS"
+    image = _child(channel, "image")
+    avatar_url = _text(image, "url") if image is not None else ""
+    entries = [
+        node for node in root.iter() if _local_name(node.tag) in {"item", "entry"}
+    ]
+    parsed = []
+    for node in entries:
+        title = clean_text(_text(node, "title"))
+        summary = clean_text(_text(node, "description", "summary", "content"))
+        if not title:
+            title = summary
+        author = clean_text(_text(node, "creator", "author"))
+        author_node = _child(node, "author")
+        if author_node is not None and not author:
+            author = clean_text(_text(author_node, "name"))
+        link_node = _child(node, "link")
+        link = ""
+        if link_node is not None:
+            link = link_node.attrib.get("href", "") or (link_node.text or "").strip()
+        link = urljoin(source.url, link)
+        identity = (
+            _text(node, "guid", "id")
+            or link
+            or f"{title}|{_text(node, 'pubdate', 'published', 'updated')}"
+        )
+        key = hashlib.sha256(f"{source.url}|{identity}".encode()).hexdigest()
+        published = _parse_date(_text(node, "pubdate", "published", "updated", "date"))
+        parsed.append(
+            FeedEntry(
+                key=key,
+                source_url=source.url,
+                kind=source.kind,
+                publication=publication,
+                title=title or "New post",
+                link=link,
+                author=author,
+                handle=source.handle,
+                avatar_url=urljoin(source.url, avatar_url),
+                published=published,
+            )
+        )
+    return parsed
+
+
+class RSSWatcher:
+    def __init__(self, sources: Optional[Iterable[FeedSource]] = None, session=None):
+        self.sources = list(configured_sources() if sources is None else sources)
+        self.enabled = os.getenv(
+            "rss_watch_enabled", "false"
+        ).lower() == "true" and bool(self.sources)
+        self.timeout = max(1, int(os.getenv("rss_watch_timeout", "10")))
+        self.show_existing = (
+            os.getenv("rss_watch_show_existing", "false").lower() == "true"
+        )
+        self.state_path = Path(
+            os.getenv("rss_watch_state_file", "cache/rss-watch-state.json")
+        )
+        self.session = session or requests.Session()
+        self._seen = self._load_state()
+
+    def _load_state(self):
+        try:
+            data = json.loads(self.state_path.read_text())
+            return {url: list(keys) for url, keys in data.get("seen", {}).items()}
+        except (OSError, ValueError, TypeError):
+            return {}
+
+    def _save_state(self):
+        self.state_path.parent.mkdir(parents=True, exist_ok=True)
+        payload = json.dumps({"seen": self._seen}, indent=2, sort_keys=True)
+        fd, temporary = tempfile.mkstemp(
+            dir=self.state_path.parent, prefix=".rss-state-"
+        )
+        try:
+            with os.fdopen(fd, "w") as handle:
+                handle.write(payload)
+            os.replace(temporary, self.state_path)
+        finally:
+            if os.path.exists(temporary):
+                os.unlink(temporary)
+
+    def poll(self) -> list[FeedEntry]:
+        new_entries = []
+        changed = False
+        for source in self.sources:
+            try:
+                response = self.session.get(source.url, timeout=self.timeout)
+                response.raise_for_status()
+                entries = parse_feed(response.content, source)
+            except Exception as exc:
+                logger.warning(
+                    "RSS poll failed for %s (%s)", source.url, type(exc).__name__
+                )
+                continue
+            previous = set(self._seen.get(source.url, []))
+            if previous or self.show_existing:
+                new_entries.extend(
+                    entry for entry in reversed(entries) if entry.key not in previous
+                )
+            if entries:
+                self._seen[source.url] = [entry.key for entry in entries[:100]]
+                changed = True
+        if changed:
+            try:
+                self._save_state()
+            except OSError as exc:
+                logger.warning("Could not save RSS state (%s)", type(exc).__name__)
+        return sorted(
+            new_entries,
+            key=lambda entry: entry.published
+            or datetime.min.replace(tzinfo=timezone.utc),
+        )

--- a/rss_service.py
+++ b/rss_service.py
@@ -8,7 +8,6 @@ import json
 import logging
 import os
 import tempfile
-import xml.etree.ElementTree as ET
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from email.utils import parsedate_to_datetime
@@ -18,6 +17,7 @@ from typing import Iterable, Optional
 from urllib.parse import quote, urljoin
 
 import requests
+from defusedxml import ElementTree as ET
 
 logger = logging.getLogger(__name__)
 
@@ -192,8 +192,10 @@ class RSSWatcher:
     def _load_state(self):
         try:
             data = json.loads(self.state_path.read_text(encoding="utf-8"))
+            if not isinstance(data, dict):
+                return {}
             return {url: list(keys) for url, keys in data.get("seen", {}).items()}
-        except (OSError, ValueError, TypeError):
+        except (OSError, ValueError, TypeError, AttributeError):
             return {}
 
     def _save_state(self):

--- a/rss_service.py
+++ b/rss_service.py
@@ -15,7 +15,7 @@ from email.utils import parsedate_to_datetime
 from html.parser import HTMLParser
 from pathlib import Path
 from typing import Iterable, Optional
-from urllib.parse import urljoin
+from urllib.parse import quote, urljoin
 
 import requests
 
@@ -95,12 +95,16 @@ class FeedEntry:
 def configured_sources() -> list[FeedSource]:
     sources = []
     nitter_base = os.getenv("rss_nitter_base_url", "").strip().rstrip("/")
+    nitter_path = os.getenv("rss_nitter_feed_path", "/{handle}/rss").strip()
+    if not nitter_path.startswith("/"):
+        nitter_path = f"/{nitter_path}"
     for handle in os.getenv("rss_nitter_users", "").split(","):
         handle = handle.strip().lstrip("@")
         if handle and nitter_base:
+            feed_path = nitter_path.replace("{handle}", quote(handle, safe=""))
             sources.append(
                 FeedSource(
-                    f"{nitter_base}/{handle}/rss",
+                    f"{nitter_base}{feed_path}",
                     kind="nitter",
                     handle=f"@{handle}",
                 )

--- a/setup.py
+++ b/setup.py
@@ -1,15 +1,26 @@
-from setuptools import setup, find_packages
+from setuptools import find_packages, setup
 
 setup(
     name="weather",
     version="0.1.0",
     packages=find_packages(),
-    py_modules=['dithering', 'font_utils', 'display_adapter', 'astronomy_utils', 'log_config', 'color_utils', 'backoff', 'token_usage', 'token_display'],
+    py_modules=[
+        "dithering",
+        "font_utils",
+        "display_adapter",
+        "astronomy_utils",
+        "log_config",
+        "color_utils",
+        "backoff",
+        "token_usage",
+        "token_display",
+    ],
     install_requires=[
         "requests>=2.32.3",
         "pydantic>=2.5.0",
         "python-dotenv>=1.0.1",
         "cairosvg>=2.9.0",
+        "defusedxml>=0.7.1",
         "Pillow>=11.0.0",
     ],
-) 
+)

--- a/tests/test_rss_display.py
+++ b/tests/test_rss_display.py
@@ -1,0 +1,23 @@
+from datetime import datetime, timezone
+
+from display_adapter import MockDisplay
+from rss_display import draw_feed_entry
+from rss_service import FeedEntry
+
+
+def test_tweet_and_generic_cards_render(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    epd = MockDisplay()
+    for kind in ("nitter", "rss"):
+        entry = FeedEntry(
+            key=kind,
+            source_url="https://example.test/feed",
+            kind=kind,
+            publication="Example Publication",
+            title="A sufficiently long post title that exercises compact wrapping on the display",
+            author="Alice Example",
+            handle="@alice",
+            published=datetime(2026, 7, 11, 10, 0, tzinfo=timezone.utc),
+        )
+        draw_feed_entry(epd, entry, set_base_image=True)
+        assert (tmp_path / "debug_output.png").stat().st_size > 0

--- a/tests/test_rss_plugin.py
+++ b/tests/test_rss_plugin.py
@@ -70,3 +70,71 @@ def test_queued_entries_render_in_order(monkeypatch):
     plugin.tick(160)
 
     assert rendered == ["one", "two"]
+
+
+def test_invalid_integer_settings_do_not_crash_startup(monkeypatch):
+    monkeypatch.setenv("rss_watch_poll_seconds", "")
+    monkeypatch.setenv("rss_watch_display_seconds", "invalid")
+    monkeypatch.setenv("rss_watch_priority", "invalid")
+    monkeypatch.setenv("rss_watch_max_queue", "invalid")
+    watcher = SimpleNamespace(enabled=True, sources=[object()])
+
+    plugin = RSSPlugin(object(), ScreenArbiter(), threading.Lock(), watcher=watcher)
+
+    assert plugin.poll_seconds == 60
+    assert plugin.duration == 60
+    assert plugin.priority == 30
+    assert plugin.max_queue == 10
+
+
+def test_run_does_not_tick_after_stop_during_poll(monkeypatch):
+    watcher = SimpleNamespace(enabled=True, sources=[object()])
+    plugin = RSSPlugin(object(), ScreenArbiter(), threading.Lock(), watcher=watcher)
+    ticks = []
+
+    def poll():
+        plugin._stop_event.set()
+        return []
+
+    watcher.poll = poll
+    monkeypatch.setattr(plugin, "tick", lambda now: ticks.append(now))
+
+    plugin._run()
+
+    assert ticks == []
+
+
+def test_oversized_avatar_is_not_buffered_for_render(monkeypatch):
+    rendered = []
+
+    class AvatarResponse:
+        def raise_for_status(self):
+            return None
+
+        def iter_content(self, chunk_size):
+            yield b"x" * 300_000
+            yield b"x" * 300_000
+
+    class AvatarSession:
+        def get(self, url, timeout, stream):
+            assert stream is True
+            return AvatarResponse()
+
+    monkeypatch.setattr(
+        "rss_plugin.draw_feed_entry",
+        lambda epd, entry, **kwargs: rendered.append(kwargs["avatar_bytes"]),
+    )
+    watcher = SimpleNamespace(
+        enabled=True,
+        sources=[object()],
+        session=AvatarSession(),
+        timeout=1,
+    )
+    plugin = RSSPlugin(object(), ScreenArbiter(), threading.Lock(), watcher=watcher)
+    entry = _entry()
+    entry = type(entry)(**{**entry.__dict__, "avatar_url": "https://example.test/a"})
+    plugin.add_entries([entry])
+
+    plugin.tick()
+
+    assert rendered == [None]

--- a/tests/test_rss_plugin.py
+++ b/tests/test_rss_plugin.py
@@ -1,0 +1,72 @@
+import threading
+from types import SimpleNamespace
+
+from rss_plugin import RSSPlugin
+from rss_service import FeedEntry
+from screen_arbiter import ScreenArbiter
+
+
+def _entry(key="one"):
+    return FeedEntry(
+        key=key,
+        source_url="https://example.test/rss",
+        kind="rss",
+        publication="Example",
+        title=f"Post {key}",
+    )
+
+
+def _plugin(monkeypatch, rendered):
+    monkeypatch.setenv("rss_watch_display_seconds", "60")
+    monkeypatch.setenv("rss_watch_priority", "30")
+    monkeypatch.setattr(
+        "rss_plugin.draw_feed_entry",
+        lambda epd, entry, **kwargs: rendered.append(entry.key),
+    )
+    watcher = SimpleNamespace(enabled=True, sources=[object()], session=None, timeout=1)
+
+    def clock():
+        return 100
+
+    return RSSPlugin(
+        object(), ScreenArbiter(clock), threading.Lock(), watcher=watcher, clock=clock
+    )
+
+
+def test_new_entry_claims_screen_for_configured_duration(monkeypatch):
+    rendered = []
+    plugin = _plugin(monkeypatch, rendered)
+    plugin.add_entries([_entry()])
+
+    plugin.tick(100)
+
+    claim = plugin.arbiter.claim_for(plugin.OWNER)
+    assert claim.priority == 30
+    assert claim.expires_at == 160
+    assert rendered == ["one"]
+
+    plugin.tick(160)
+    assert plugin.arbiter.active_owner() is None
+
+
+def test_higher_priority_owner_overrides_rss(monkeypatch):
+    rendered = []
+    plugin = _plugin(monkeypatch, rendered)
+    plugin.arbiter.claim("flight", 50, 30)
+    plugin.add_entries([_entry()])
+
+    plugin.tick(100)
+
+    assert plugin.arbiter.active_owner() == "flight"
+    assert rendered == []
+
+
+def test_queued_entries_render_in_order(monkeypatch):
+    rendered = []
+    plugin = _plugin(monkeypatch, rendered)
+    plugin.add_entries([_entry("one"), _entry("two")])
+
+    plugin.tick(100)
+    plugin.tick(160)
+
+    assert rendered == ["one", "two"]

--- a/tests/test_rss_service.py
+++ b/tests/test_rss_service.py
@@ -1,6 +1,7 @@
 from datetime import timezone
 
-from rss_service import FeedSource, RSSWatcher, configured_sources, parse_feed
+from rss_service import (FeedSource, RSSWatcher, configured_sources, env_int,
+                         parse_feed)
 
 RSS = b"""<?xml version="1.0"?>
 <rss version="2.0" xmlns:dc="http://purl.org/dc/elements/1.1/">
@@ -71,6 +72,12 @@ def test_configured_sources_supports_nitter_with_replies_path(monkeypatch):
     monkeypatch.delenv("rss_feed_urls", raising=False)
 
     assert configured_sources()[0].url == ("http://nitter.local/alice/with_replies/rss")
+
+
+def test_invalid_integer_environment_uses_default(monkeypatch):
+    monkeypatch.setenv("rss_watch_timeout", "not-a-number")
+
+    assert env_int("rss_watch_timeout", 10) == 10
 
 
 def test_first_poll_baselines_and_later_poll_returns_only_new_entry(

--- a/tests/test_rss_service.py
+++ b/tests/test_rss_service.py
@@ -80,6 +80,16 @@ def test_invalid_integer_environment_uses_default(monkeypatch):
     assert env_int("rss_watch_timeout", 10) == 10
 
 
+def test_non_object_state_file_recovers_as_empty(monkeypatch, tmp_path):
+    state_path = tmp_path / "state.json"
+    state_path.write_text("null", encoding="utf-8")
+    monkeypatch.setenv("rss_watch_state_file", str(state_path))
+
+    watcher = RSSWatcher([], session=Session([]))
+
+    assert watcher._seen == {}
+
+
 def test_first_poll_baselines_and_later_poll_returns_only_new_entry(
     monkeypatch, tmp_path
 ):

--- a/tests/test_rss_service.py
+++ b/tests/test_rss_service.py
@@ -64,6 +64,15 @@ def test_configured_sources_builds_nitter_and_arbitrary_feeds(monkeypatch):
     assert [source.kind for source in sources] == ["nitter", "nitter", "rss", "rss"]
 
 
+def test_configured_sources_supports_nitter_with_replies_path(monkeypatch):
+    monkeypatch.setenv("rss_nitter_base_url", "http://nitter.local")
+    monkeypatch.setenv("rss_nitter_users", "alice")
+    monkeypatch.setenv("rss_nitter_feed_path", "/{handle}/with_replies/rss")
+    monkeypatch.delenv("rss_feed_urls", raising=False)
+
+    assert configured_sources()[0].url == ("http://nitter.local/alice/with_replies/rss")
+
+
 def test_first_poll_baselines_and_later_poll_returns_only_new_entry(
     monkeypatch, tmp_path
 ):

--- a/tests/test_rss_service.py
+++ b/tests/test_rss_service.py
@@ -1,0 +1,86 @@
+from datetime import timezone
+
+from rss_service import FeedSource, RSSWatcher, configured_sources, parse_feed
+
+RSS = b"""<?xml version="1.0"?>
+<rss version="2.0" xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <channel>
+    <title>Alice / Nitter</title>
+    <image><url>/pic/avatar.jpg</url></image>
+    <item>
+      <title>Hello &amp; welcome to &lt;b&gt;the feed&lt;/b&gt;</title>
+      <dc:creator>Alice Example</dc:creator>
+      <link>https://nitter.test/alice/status/1</link>
+      <guid>tweet-1</guid>
+      <pubDate>Sat, 11 Jul 2026 10:00:00 GMT</pubDate>
+    </item>
+  </channel>
+</rss>"""
+
+
+class Response:
+    def __init__(self, content):
+        self.content = content
+
+    def raise_for_status(self):
+        return None
+
+
+class Session:
+    def __init__(self, contents):
+        self.contents = list(contents)
+
+    def get(self, url, timeout):
+        return Response(self.contents.pop(0))
+
+
+def test_nitter_feed_parses_identity_text_and_avatar():
+    source = FeedSource("https://nitter.test/alice/rss", "nitter", handle="@alice")
+
+    entry = parse_feed(RSS, source)[0]
+
+    assert entry.kind == "nitter"
+    assert entry.publication == "Alice / Nitter"
+    assert entry.author == "Alice Example"
+    assert entry.handle == "@alice"
+    assert entry.title == "Hello & welcome to the feed"
+    assert entry.avatar_url == "https://nitter.test/pic/avatar.jpg"
+    assert entry.published.tzinfo == timezone.utc
+
+
+def test_configured_sources_builds_nitter_and_arbitrary_feeds(monkeypatch):
+    monkeypatch.setenv("rss_nitter_base_url", "http://nitter.local/")
+    monkeypatch.setenv("rss_nitter_users", "alice, @bob")
+    monkeypatch.setenv("rss_feed_urls", "https://example.com/rss, https://x.test/atom")
+
+    sources = configured_sources()
+
+    assert [source.url for source in sources] == [
+        "http://nitter.local/alice/rss",
+        "http://nitter.local/bob/rss",
+        "https://example.com/rss",
+        "https://x.test/atom",
+    ]
+    assert [source.kind for source in sources] == ["nitter", "nitter", "rss", "rss"]
+
+
+def test_first_poll_baselines_and_later_poll_returns_only_new_entry(
+    monkeypatch, tmp_path
+):
+    second = RSS.replace(
+        b"<item>",
+        b"<item><title>Second post</title><guid>tweet-2</guid></item><item>",
+        1,
+    )
+    monkeypatch.setenv("rss_watch_enabled", "true")
+    monkeypatch.setenv("rss_watch_state_file", str(tmp_path / "state.json"))
+    watcher = RSSWatcher(
+        [FeedSource("https://nitter.test/alice/rss", "nitter")],
+        session=Session([RSS, second]),
+    )
+
+    assert watcher.poll() == []
+    new_entries = watcher.poll()
+
+    assert [entry.title for entry in new_entries] == ["Second post"]
+    assert (tmp_path / "state.json").exists()


### PR DESCRIPTION
## Summary
- add persisted RSS/Atom polling with Nitter username shortcuts and baseline-safe new-entry detection
- render compact Nitter cards with author, handle, tweet text, and optional feed avatar, plus publication/title cards for generic feeds
- queue notifications through the shared screen arbiter at configurable priority and duration
- document private configuration and priority behavior

## Priority design
The default RSS priority is 30. It interrupts the scheduled base display and calendar agenda glances, while yielding to upcoming calendar events (40), flights (50), and priority ISS (60). All values remain configurable.

## Verification
- `pytest -q` (221 passed)
- focused flake8 checks for the new modules and tests
- native 250x120 MockDisplay render inspected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional RSS/Atom and Nitter feed watcher.
  * Displays new feed entries, including posts, titles, authors, publication times, and optional avatars.
  * Supports configurable polling, display duration, priority, queue limits, feed sources, and persisted seen-item history.
  * Integrates feed notifications with existing screen-priority behavior.

* **Documentation**
  * Added setup and usage guidance for RSS/Nitter monitoring and screen arbitration.
  * Expanded configuration examples.

* **Tests**
  * Added coverage for feed parsing, polling, persistence, rendering, queueing, and display priority.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->