### PR TITLE
Add configurable breaking-news display

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -140,6 +140,23 @@ rss_watch_timeout=10
 rss_watch_state_file=cache/rss-watch-state.json
 rss_watch_show_existing=false
 
+# Optional breaking-news watcher. Feed URLs and authentication headers belong
+# in the ignored JSON file, not here or in Git. The first successful poll only
+# establishes a baseline. See docs/breaking-news-display.md.
+breaking_news_enabled=false
+breaking_news_config_file=breaking-news-feeds.json
+breaking_news_poll_seconds=300
+breaking_news_display_seconds=240
+breaking_news_priority=70
+breaking_news_max_queue=3
+breaking_news_timeout=10
+breaking_news_max_feed_bytes=1048576
+breaking_news_user_agent=rpi-waiting-time-display/1.0 feed reader
+breaking_news_max_age_seconds=21600
+breaking_news_seen_per_source=200
+breaking_news_max_fingerprints=500
+breaking_news_state_file=cache/breaking-news-state.json
+
 # Weather settings
 WEATHER_PROVIDER=openmeteo  # openmeteo or openweather
 OPENWEATHER_API_KEY=  # Only needed if using openweather provider

--- a/.gitignore.example
+++ b/.gitignore.example
@@ -2,6 +2,7 @@
 __pycache__
 __pycache__/*
 .env
+breaking-news-feeds.json
 .gitignore
 logs/*
 debug_output.png

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,6 +77,7 @@ python webserial_server.py
 - **token_usage.py**: Optional schedule parser and normalized token-usage client
 - **token_display.py**: Compact month-to-date and rate-limit e-paper views
 - **rss_service.py**, **rss_plugin.py**: RSS/Nitter polling and arbitrated notifications
+- **breaking_news_service.py**, **breaking_news_plugin.py**: baseline-first breaking-news polling and arbitrated alerts
 - **tools/token_usage_server.py**: Authenticated bridge for a remote usage source
 
 ### Key Design Patterns

--- a/basic.py
+++ b/basic.py
@@ -30,6 +30,7 @@ from token_usage import (
 )
 from screen_arbiter import ScreenArbiter
 from rss_plugin import RSSPlugin
+from breaking_news_plugin import BreakingNewsPlugin
 from calendar_plugin import CalendarPlugin
 
 logger = logging.getLogger(__name__)
@@ -333,6 +334,12 @@ class DisplayManager:
             self._display_lock,
             on_render=self._plugin_rendered,
         )
+        self.breaking_news_plugin = BreakingNewsPlugin(
+            epd,
+            self.screen_arbiter,
+            self._display_lock,
+            on_render=self._plugin_rendered,
+        )
         logger.info(f"DisplayManager initialized with min refresh interval: {self.min_refresh_interval}s")
         logger.info(f"DisplayManager initialized with coordinates: {self.coordinates_lat}, {self.coordinates_lng}")
         logger.info(f"DisplayManager initialized with flight mode duration: {self.flight_mode_duration}s")
@@ -416,6 +423,7 @@ class DisplayManager:
         # transit/weather/token data sources.
         self.calendar_plugin.start()
         self.rss_plugin.start()
+        self.breaking_news_plugin.start()
         
         # Token views do not depend on transit either. The normal update loop
         # will prefetch it when a transit or automatic window becomes active.
@@ -891,6 +899,7 @@ class DisplayManager:
 
         self.calendar_plugin.stop()
         self.rss_plugin.stop()
+        self.breaking_news_plugin.stop()
             
         for thread in [self._check_data_thread, self._flight_thread, self._iss_thread]:
             if thread:

--- a/breaking_news_display.py
+++ b/breaking_news_display.py
@@ -1,0 +1,29 @@
+"""High-contrast breaking-news card for the 250x120 e-paper canvas."""
+
+from PIL import Image, ImageDraw
+
+from rss_display import _ellipsize, _finish, _fonts, _wrap
+
+
+def draw_breaking_news(epd, entry, *, set_base_image=False):
+    white = epd.WHITE if not epd.is_bw_display else 1
+    black = epd.BLACK if not epd.is_bw_display else 0
+    image = Image.new(
+        "1" if epd.is_bw_display else "RGB", (epd.height, epd.width), white
+    )
+    draw = ImageDraw.Draw(image)
+    header, title_font, _, tiny = _fonts()
+
+    draw.rectangle((0, 0, 249, 25), fill=black)
+    draw.text((7, 5), "BREAKING NEWS", font=header, fill=white)
+    time_label = "NEW"
+    if entry.published:
+        time_label = entry.published.astimezone().strftime("%H:%M")
+    time_width = draw.textbbox((0, 0), time_label, font=tiny)[2]
+    draw.text((243 - time_width, 7), time_label, font=tiny, fill=white)
+    source = _ellipsize(draw, entry.publication.upper(), tiny, 236)
+    draw.text((7, 31), source, font=tiny, fill=black)
+    draw.line((7, 44, 243, 44), fill=black, width=1)
+    for index, line in enumerate(_wrap(draw, entry.title, title_font, 236, 4)):
+        draw.text((7, 50 + index * 17), line, font=title_font, fill=black)
+    _finish(epd, image, set_base_image)

--- a/breaking_news_plugin.py
+++ b/breaking_news_plugin.py
@@ -1,0 +1,114 @@
+"""Breaking-news display plugin backed by the shared screen arbiter."""
+
+import logging
+import threading
+import time
+from collections import deque
+
+from breaking_news_display import draw_breaking_news
+from breaking_news_service import BreakingNewsWatcher
+from rss_service import env_int
+
+logger = logging.getLogger(__name__)
+
+
+class BreakingNewsPlugin:
+    OWNER = "breaking-news"
+
+    def __init__(
+        self,
+        epd,
+        arbiter,
+        display_lock,
+        *,
+        watcher=None,
+        on_render=None,
+        clock=None,
+    ):
+        self.epd = epd
+        self.arbiter = arbiter
+        self.display_lock = display_lock
+        self.watcher = watcher or BreakingNewsWatcher()
+        self.on_render = on_render
+        self.clock = clock or time.monotonic
+        self.enabled = self.watcher.enabled
+        self.poll_seconds = max(60, env_int("breaking_news_poll_seconds", 300))
+        self.duration = max(30, env_int("breaking_news_display_seconds", 240))
+        self.priority = env_int("breaking_news_priority", 70)
+        self.max_queue = max(1, env_int("breaking_news_max_queue", 3))
+        self._queue = deque()
+        self._active_until = None
+        self._rendered_key = None
+        self._thread = None
+        self._stop_event = threading.Event()
+
+    def start(self):
+        if not self.enabled or self._thread:
+            return
+        self._thread = threading.Thread(
+            target=self._run, name="BreakingNewsPlugin", daemon=True
+        )
+        self._thread.start()
+        logger.info(
+            "Breaking-news watcher started for %d feeds",
+            len(self.watcher.sources),
+        )
+
+    def stop(self):
+        self._stop_event.set()
+        if self._thread:
+            self._thread.join(timeout=1.0)
+        self.arbiter.release(self.OWNER)
+
+    def _run(self):
+        next_poll = 0.0
+        while not self._stop_event.is_set():
+            now = self.clock()
+            if now >= next_poll:
+                try:
+                    self.add_entries(self.watcher.poll())
+                except Exception as exc:
+                    logger.warning(
+                        "Breaking-news update failed (%s)", type(exc).__name__
+                    )
+                next_poll = now + self.poll_seconds
+            if not self._stop_event.is_set():
+                self.tick(now)
+            self._stop_event.wait(1.0)
+
+    def add_entries(self, entries):
+        known = {entry.key for entry in self._queue}
+        for entry in entries:
+            if entry.key not in known:
+                self._queue.append(entry)
+                known.add(entry.key)
+        while len(self._queue) > self.max_queue:
+            self._queue.popleft()
+
+    def tick(self, now=None):
+        now = self.clock() if now is None else now
+        if self._active_until is not None and now >= self._active_until:
+            if self._queue:
+                self._queue.popleft()
+            self._active_until = None
+            self._rendered_key = None
+            self.arbiter.release(self.OWNER)
+        if not self._queue:
+            self.arbiter.release(self.OWNER)
+            return
+        if self._active_until is None:
+            self._active_until = now + self.duration
+        if not self.arbiter.claim(
+            self.OWNER, self.priority, max(1, self._active_until - now)
+        ):
+            return
+        entry = self._queue[0]
+        if entry.key == self._rendered_key:
+            return
+        with self.display_lock:
+            if not self.arbiter.can_render(self.OWNER):
+                return
+            draw_breaking_news(self.epd, entry, set_base_image=True)
+            self._rendered_key = entry.key
+            if self.on_render:
+                self.on_render(self.OWNER)

--- a/breaking_news_service.py
+++ b/breaking_news_service.py
@@ -1,0 +1,278 @@
+# flake8: noqa: E501
+"""Baseline-first breaking-news feed watcher with bounded persistent state."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+import re
+import tempfile
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Iterable, Optional
+from urllib.parse import urlsplit
+
+import requests
+
+from rss_service import FeedEntry, FeedSource, env_int, parse_feed
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_KEYWORDS = (
+    "breaking",
+    "breaking news",
+    "urgent",
+    "news alert",
+    "developing",
+)
+
+
+@dataclass(frozen=True)
+class BreakingSource:
+    url: str
+    label: str = ""
+    match: str = "keywords"
+    keywords: tuple[str, ...] = DEFAULT_KEYWORDS
+    headers: tuple[tuple[str, str], ...] = ()
+
+
+def _source_from_dict(value) -> Optional[BreakingSource]:
+    if not isinstance(value, dict) or not str(value.get("url", "")).strip():
+        return None
+    match = str(value.get("match", "keywords")).strip().lower()
+    if match not in {"keywords", "all"}:
+        logger.warning("Ignoring breaking-news source with invalid match mode")
+        return None
+    keywords = value.get("keywords", DEFAULT_KEYWORDS)
+    if not isinstance(keywords, (list, tuple)) or not all(
+        isinstance(item, str) for item in keywords
+    ):
+        logger.warning("Ignoring breaking-news source with invalid keywords")
+        return None
+    headers = value.get("headers", {})
+    if not isinstance(headers, dict) or not all(
+        isinstance(key, str) and isinstance(item, str) for key, item in headers.items()
+    ):
+        logger.warning("Ignoring breaking-news source with invalid headers")
+        return None
+    return BreakingSource(
+        url=str(value["url"]).strip(),
+        label=str(value.get("label", "")).strip(),
+        match=match,
+        keywords=tuple(item.strip().lower() for item in keywords if item.strip()),
+        headers=tuple(headers.items()),
+    )
+
+
+def configured_breaking_sources() -> list[BreakingSource]:
+    """Load feed details from a private, untracked JSON file."""
+
+    path = Path(os.getenv("breaking_news_config_file", "breaking-news-feeds.json"))
+    try:
+        values = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        return []
+    except (OSError, ValueError, TypeError):
+        logger.warning("Could not read breaking-news source configuration")
+        return []
+    if not isinstance(values, list):
+        logger.warning("Breaking-news source configuration must be a JSON list")
+        return []
+    return [source for value in values if (source := _source_from_dict(value))]
+
+
+def headline_fingerprint(title: str) -> str:
+    normalized = re.sub(
+        r"^(breaking(?: news)?|urgent|news alert|developing)\s*[:\-–—|]*\s*",
+        "",
+        title.casefold(),
+    )
+    normalized = re.sub(r"[^\w]+", " ", normalized, flags=re.UNICODE).strip()
+    return hashlib.sha256(normalized.encode("utf-8")).hexdigest()
+
+
+def _safe_source_name(url: str) -> str:
+    parsed = urlsplit(url)
+    return parsed.hostname or "configured source"
+
+
+class BreakingNewsWatcher:
+    def __init__(
+        self,
+        sources: Optional[Iterable[BreakingSource]] = None,
+        session=None,
+        now=None,
+    ):
+        self.sources = list(
+            configured_breaking_sources() if sources is None else sources
+        )
+        self.enabled = os.getenv(
+            "breaking_news_enabled", "false"
+        ).lower() == "true" and bool(self.sources)
+        self.timeout = max(1, env_int("breaking_news_timeout", 10))
+        self.max_age = max(60, env_int("breaking_news_max_age_seconds", 21600))
+        self.max_feed_bytes = max(
+            1024, env_int("breaking_news_max_feed_bytes", 1048576)
+        )
+        self.max_seen_per_source = max(
+            10, env_int("breaking_news_seen_per_source", 200)
+        )
+        self.max_fingerprints = max(10, env_int("breaking_news_max_fingerprints", 500))
+        self.state_path = Path(
+            os.getenv("breaking_news_state_file", "cache/breaking-news-state.json")
+        )
+        self.session = session or requests.Session()
+        self.now = now or (lambda: datetime.now(timezone.utc))
+        self._state = self._load_state()
+
+    def _content(self, response) -> bytes:
+        content = bytearray()
+        for chunk in response.iter_content(chunk_size=16_384):
+            content.extend(chunk)
+            if len(content) > self.max_feed_bytes:
+                raise ValueError("feed exceeds configured size limit")
+        return bytes(content)
+
+    def _prune_sources(self):
+        active = {source.url for source in self.sources}
+        for key in ("seen", "validators"):
+            self._state[key] = {
+                url: value for url, value in self._state[key].items() if url in active
+            }
+
+    def _load_state(self):
+        try:
+            value = json.loads(self.state_path.read_text(encoding="utf-8"))
+            if not isinstance(value, dict):
+                raise ValueError
+            seen = value.get("seen", {})
+            fingerprints = value.get("fingerprints", [])
+            validators = value.get("validators", {})
+            if (
+                not isinstance(seen, dict)
+                or not isinstance(fingerprints, list)
+                or not isinstance(validators, dict)
+            ):
+                raise ValueError
+            return {
+                "seen": seen,
+                "fingerprints": fingerprints,
+                "validators": validators,
+            }
+        except (OSError, ValueError, TypeError):
+            return {"seen": {}, "fingerprints": [], "validators": {}}
+
+    def _save_state(self):
+        self.state_path.parent.mkdir(parents=True, exist_ok=True)
+        fd, temporary = tempfile.mkstemp(
+            dir=self.state_path.parent, prefix=".breaking-state-"
+        )
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as handle:
+                json.dump(self._state, handle, indent=2, sort_keys=True)
+            os.replace(temporary, self.state_path)
+        finally:
+            if os.path.exists(temporary):
+                os.unlink(temporary)
+
+    @staticmethod
+    def _qualifies(entry: FeedEntry, source: BreakingSource) -> bool:
+        if source.match == "all":
+            return True
+        title = entry.title.casefold()
+        return any(keyword in title for keyword in source.keywords)
+
+    def _fresh(self, entry: FeedEntry) -> bool:
+        if entry.published is None:
+            return True
+        published = entry.published
+        if published.tzinfo is None:
+            published = published.replace(tzinfo=timezone.utc)
+        return published >= self.now() - timedelta(seconds=self.max_age)
+
+    def poll(self) -> list[FeedEntry]:
+        self._prune_sources()
+        new_entries = []
+        changed = False
+        known_fingerprints = set(self._state["fingerprints"])
+        for source in self.sources:
+            validator = self._state["validators"].get(source.url, {})
+            headers = dict(source.headers)
+            headers.setdefault(
+                "User-Agent",
+                os.getenv(
+                    "breaking_news_user_agent",
+                    "rpi-waiting-time-display/1.0 feed reader",
+                ),
+            )
+            if validator.get("etag"):
+                headers["If-None-Match"] = validator["etag"]
+            if validator.get("last_modified"):
+                headers["If-Modified-Since"] = validator["last_modified"]
+            try:
+                response = self.session.get(
+                    source.url,
+                    timeout=self.timeout,
+                    headers=headers,
+                    stream=True,
+                )
+                try:
+                    if response.status_code == 304:
+                        continue
+                    response.raise_for_status()
+                    entries = parse_feed(
+                        self._content(response),
+                        FeedSource(source.url, kind="breaking", label=source.label),
+                    )
+                finally:
+                    response.close()
+            except Exception as exc:
+                logger.warning(
+                    "Breaking-news poll failed for %s (%s)",
+                    _safe_source_name(source.url),
+                    type(exc).__name__,
+                )
+                continue
+
+            previous = set(self._state["seen"].get(source.url, []))
+            # An unknown feed is baseline-only. This prevents old headlines
+            # from being announced after first enablement or state loss.
+            if previous:
+                for entry in reversed(entries):
+                    fingerprint = headline_fingerprint(entry.title)
+                    if (
+                        entry.key not in previous
+                        and fingerprint not in known_fingerprints
+                        and self._qualifies(entry, source)
+                        and self._fresh(entry)
+                    ):
+                        new_entries.append(entry)
+                        known_fingerprints.add(fingerprint)
+                        self._state["fingerprints"].append(fingerprint)
+            self._state["seen"][source.url] = [
+                entry.key for entry in entries[: self.max_seen_per_source]  # noqa: E203
+            ]
+            self._state["fingerprints"] = self._state["fingerprints"][
+                -self.max_fingerprints :  # noqa: E203
+            ]
+            self._state["validators"][source.url] = {
+                "etag": response.headers.get("ETag", ""),
+                "last_modified": response.headers.get("Last-Modified", ""),
+            }
+            changed = True
+        if changed:
+            try:
+                self._save_state()
+            except OSError as exc:
+                logger.warning(
+                    "Could not save breaking-news state (%s)",
+                    type(exc).__name__,
+                )
+        return sorted(
+            new_entries,
+            key=lambda entry: entry.published
+            or datetime.min.replace(tzinfo=timezone.utc),
+        )

--- a/breaking_news_service.py
+++ b/breaking_news_service.py
@@ -40,29 +40,38 @@ class BreakingSource:
 
 
 def _source_from_dict(value) -> Optional[BreakingSource]:
-    if not isinstance(value, dict) or not str(value.get("url", "")).strip():
+    if not isinstance(value, dict):
         return None
-    match = str(value.get("match", "keywords")).strip().lower()
+    url = value.get("url")
+    if not isinstance(url, str) or not url.strip():
+        return None
+    match_value = value.get("match")
+    match = str(match_value).strip().lower() if match_value is not None else "keywords"
     if match not in {"keywords", "all"}:
         logger.warning("Ignoring breaking-news source with invalid match mode")
         return None
-    keywords = value.get("keywords", DEFAULT_KEYWORDS)
+    keywords = value.get("keywords")
+    if keywords is None:
+        keywords = DEFAULT_KEYWORDS
     if not isinstance(keywords, (list, tuple)) or not all(
         isinstance(item, str) for item in keywords
     ):
         logger.warning("Ignoring breaking-news source with invalid keywords")
         return None
-    headers = value.get("headers", {})
+    headers = value.get("headers")
+    if headers is None:
+        headers = {}
     if not isinstance(headers, dict) or not all(
         isinstance(key, str) and isinstance(item, str) for key, item in headers.items()
     ):
         logger.warning("Ignoring breaking-news source with invalid headers")
         return None
+    label = value.get("label")
     return BreakingSource(
-        url=str(value["url"]).strip(),
-        label=str(value.get("label", "")).strip(),
+        url=url.strip(),
+        label=str(label).strip() if label is not None else "",
         match=match,
-        keywords=tuple(item.strip().lower() for item in keywords if item.strip()),
+        keywords=tuple(item.strip().casefold() for item in keywords if item.strip()),
         headers=tuple(headers.items()),
     )
 

--- a/docs/breaking-news-display.md
+++ b/docs/breaking-news-display.md
@@ -1,0 +1,71 @@
+# Breaking-news display
+
+The optional breaking-news module watches explicitly configured RSS/Atom feeds
+and shows a high-contrast headline card for about four minutes. It does not
+scrape news sites. It is disabled unless both `breaking_news_enabled=true` and
+at least one valid source are present.
+
+## Private source configuration
+
+Keep source URLs, API keys, and customer-specific feed identifiers in the
+ignored `breaking-news-feeds.json` file (or point `breaking_news_config_file` at
+another private path):
+
+```json
+[
+  {
+    "url": "https://feeds.bbci.co.uk/news/rss.xml",
+    "label": "BBC News",
+    "match": "keywords"
+  },
+  {
+    "url": "https://licensed-provider.example/breaking.xml",
+    "label": "Licensed wire",
+    "match": "all",
+    "headers": {"Authorization": "Bearer keep-this-out-of-git"}
+  }
+]
+```
+
+`match: "keywords"` only announces new headlines containing the source's
+`keywords` list, which defaults to `breaking`, `breaking news`, `urgent`,
+`news alert`, and `developing`. Override it per source when the publisher uses
+different labels. Use `match: "all"` only for a feed whose publisher defines
+every item as breaking; using it on a general news feed creates false alerts.
+
+BBC publishes an official headline RSS feed at the URL shown above. AP offers
+authenticated feeds and RSS products to entitled Media API customers; use only
+the URLs and credentials supplied under your AP plan. This module does not ship
+AP, CNN, or Reuters URLs: no unauthenticated official breaking RSS endpoint is
+assumed for them. A publisher-provided or licensed RSS/Atom URL can be added
+without a code change when its terms allow this use.
+
+## New-item detection and failure behavior
+
+The first successful poll of each source establishes a baseline and displays
+nothing. Later items must be unseen, recent, match the source rule, and have a
+headline not already announced by another source. Prefixes and punctuation are
+normalized for cross-feed deduplication. Items older than
+`breaking_news_max_age_seconds` are ignored, preventing stale feed reorderings
+from becoming alerts.
+
+State is written atomically to `cache/breaking-news-state.json`. Per-feed IDs,
+cross-feed fingerprints, and the on-screen queue are bounded by configuration.
+A missing or corrupt state file safely returns to baseline behavior. Failed
+sources are logged without blocking healthy sources or the normal display.
+
+Polling defaults to five minutes and cannot be configured below 60 seconds.
+ETag and Last-Modified validators are retained and sent on later requests, so
+publishers can answer with `304 Not Modified`. Use longer intervals if required
+by a feed's terms. Requests carry a configurable user agent and feed bodies are
+limited to 1 MiB by default. Failure logs identify only the source hostname, so
+credentials embedded in private paths or query strings are not printed.
+
+## Display arbitration
+
+Each queued headline gets a 240-second, non-exclusive claim at priority `70`.
+It normally interrupts the base, RSS, flight, and ISS screens, while a higher
+priority or exclusive claim can override it. The four-minute timer is
+wall-clock based and continues during an override, so a delayed alert cannot
+take over the display indefinitely afterward. At most three alerts are queued
+by default; the oldest excess alert is discarded.

--- a/docs/screen-arbiter.md
+++ b/docs/screen-arbiter.md
@@ -37,3 +37,8 @@ while holding the display lock immediately before writing to the device.
 The RSS watcher defaults to priority `30`: it interrupts the scheduled base
 screen and calendar agenda glances, but yields to upcoming calendar events,
 flights, and the priority ISS view. Set `rss_watch_priority` to change this.
+
+Breaking-news alerts default to priority `70` and a non-exclusive four-minute
+claim. Higher-priority or exclusive claims still win; the alert's wall-clock
+duration continues while it is pre-empted. Set `breaking_news_priority` to fit
+the local priority policy.

--- a/tests/test_breaking_news_display.py
+++ b/tests/test_breaking_news_display.py
@@ -1,0 +1,24 @@
+from datetime import datetime, timezone
+
+from breaking_news_display import draw_breaking_news
+from display_adapter import MockDisplay
+from rss_service import FeedEntry
+
+
+def test_breaking_news_card_renders_on_213_inch_canvas(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    entry = FeedEntry(
+        key="breaking-1",
+        source_url="https://example.test/feed",
+        kind="breaking",
+        publication="Example News Wire",
+        title=(
+            "Breaking: a sufficiently long headline wraps cleanly across "
+            "the compact e-paper display"
+        ),
+        published=datetime(2026, 7, 11, 10, 0, tzinfo=timezone.utc),
+    )
+
+    draw_breaking_news(MockDisplay(), entry, set_base_image=True)
+
+    assert (tmp_path / "debug_output.png").stat().st_size > 0

--- a/tests/test_breaking_news_plugin.py
+++ b/tests/test_breaking_news_plugin.py
@@ -1,0 +1,77 @@
+import threading
+from types import SimpleNamespace
+
+from breaking_news_plugin import BreakingNewsPlugin
+from rss_service import FeedEntry
+from screen_arbiter import ScreenArbiter
+
+
+def _entry(key="one"):
+    return FeedEntry(
+        key, "https://news.test/rss", "breaking", "News", f"Headline {key}"
+    )
+
+
+def _plugin(monkeypatch, rendered):
+    monkeypatch.setenv("breaking_news_display_seconds", "240")
+    monkeypatch.setenv("breaking_news_priority", "70")
+
+    def render(epd, entry, **kwargs):
+        rendered.append(entry.key)
+
+    monkeypatch.setattr(
+        "breaking_news_plugin.draw_breaking_news",
+        render,
+    )
+    watcher = SimpleNamespace(enabled=True, sources=[object()])
+
+    def clock():
+        return 100
+
+    return BreakingNewsPlugin(
+        object(),
+        ScreenArbiter(clock),
+        threading.Lock(),
+        watcher=watcher,
+        clock=clock,
+    )
+
+
+def test_alert_claims_screen_for_four_minutes(monkeypatch):
+    rendered = []
+    plugin = _plugin(monkeypatch, rendered)
+    plugin.add_entries([_entry()])
+
+    plugin.tick(100)
+
+    claim = plugin.arbiter.claim_for(plugin.OWNER)
+    assert claim.priority == 70
+    assert claim.expires_at == 340
+    assert claim.exclusive is False
+    assert rendered == ["one"]
+
+
+def test_higher_priority_override_wins_and_alert_expires_in_wall_clock_time(
+    monkeypatch,
+):
+    rendered = []
+    plugin = _plugin(monkeypatch, rendered)
+    plugin.arbiter.claim("critical", 100, 300)
+    plugin.add_entries([_entry()])
+
+    plugin.tick(100)
+    plugin.tick(340)
+
+    assert rendered == []
+    assert plugin.arbiter.active_owner() == "critical"
+    assert not plugin._queue
+
+
+def test_queue_is_bounded(monkeypatch):
+    rendered = []
+    monkeypatch.setenv("breaking_news_max_queue", "2")
+    plugin = _plugin(monkeypatch, rendered)
+
+    plugin.add_entries([_entry("one"), _entry("two"), _entry("three")])
+
+    assert [entry.key for entry in plugin._queue] == ["two", "three"]

--- a/tests/test_breaking_news_service.py
+++ b/tests/test_breaking_news_service.py
@@ -85,6 +85,48 @@ def test_private_config_supports_rules_and_headers(monkeypatch, tmp_path):
     ]
 
 
+def test_private_config_rejects_null_url_and_defaults_null_options(
+    monkeypatch, tmp_path
+):
+    path = tmp_path / "feeds.json"
+    path.write_text(
+        json.dumps(
+            [
+                {"url": None, "label": None},
+                {
+                    "url": "https://wire.test/feed",
+                    "label": None,
+                    "match": None,
+                    "keywords": None,
+                    "headers": None,
+                },
+            ]
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("breaking_news_config_file", str(path))
+
+    assert configured_breaking_sources() == [BreakingSource("https://wire.test/feed")]
+
+
+def test_keyword_normalization_uses_unicode_case_folding(monkeypatch, tmp_path):
+    path = tmp_path / "feeds.json"
+    path.write_text(
+        json.dumps(
+            [
+                {
+                    "url": "https://wire.test/feed",
+                    "keywords": ["STRAẞE"],
+                }
+            ]
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("breaking_news_config_file", str(path))
+
+    assert configured_breaking_sources()[0].keywords == ("strasse",)
+
+
 def test_first_poll_baselines_then_only_new_matching_headline_is_returned(
     monkeypatch, tmp_path
 ):

--- a/tests/test_breaking_news_service.py
+++ b/tests/test_breaking_news_service.py
@@ -1,0 +1,172 @@
+# flake8: noqa: E501
+import json
+from datetime import datetime, timezone
+
+from breaking_news_service import (
+    BreakingNewsWatcher,
+    BreakingSource,
+    configured_breaking_sources,
+    headline_fingerprint,
+)
+
+
+def _rss(*items):
+    body = "".join(
+        f"<item><title>{title}</title><guid>{guid}</guid>"
+        f"<pubDate>Sat, 11 Jul 2026 10:00:00 GMT</pubDate></item>"
+        for guid, title in items
+    )
+    return (f"<rss><channel><title>News Wire</title>{body}</channel></rss>").encode()
+
+
+class Response:
+    def __init__(self, content=b"", status=200, headers=None):
+        self.content = content
+        self.status_code = status
+        self.headers = headers or {}
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise RuntimeError("request failed")
+
+    def iter_content(self, chunk_size):
+        yield self.content
+
+    def close(self):
+        return None
+
+
+class Session:
+    def __init__(self, responses):
+        self.responses = list(responses)
+        self.requests = []
+
+    def get(self, url, timeout, headers, stream):
+        self.requests.append((url, timeout, headers, stream))
+        return self.responses.pop(0)
+
+
+def _watcher(monkeypatch, tmp_path, sources, responses):
+    monkeypatch.setenv("breaking_news_enabled", "true")
+    monkeypatch.setenv("breaking_news_state_file", str(tmp_path / "state.json"))
+    return BreakingNewsWatcher(
+        sources,
+        session=Session(responses),
+        now=lambda: datetime(2026, 7, 11, 10, 5, tzinfo=timezone.utc),
+    )
+
+
+def test_private_config_supports_rules_and_headers(monkeypatch, tmp_path):
+    path = tmp_path / "feeds.json"
+    path.write_text(
+        json.dumps(
+            [
+                {
+                    "url": "https://wire.test/feed",
+                    "label": "Wire",
+                    "match": "all",
+                    "headers": {"Authorization": "Bearer secret"},
+                }
+            ]
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("breaking_news_config_file", str(path))
+
+    sources = configured_breaking_sources()
+
+    assert sources == [
+        BreakingSource(
+            "https://wire.test/feed",
+            "Wire",
+            "all",
+            headers=(("Authorization", "Bearer secret"),),
+        )
+    ]
+
+
+def test_first_poll_baselines_then_only_new_matching_headline_is_returned(
+    monkeypatch, tmp_path
+):
+    source = BreakingSource("https://news.test/rss", label="News")
+    watcher = _watcher(
+        monkeypatch,
+        tmp_path,
+        [source],
+        [
+            Response(_rss(("1", "Breaking: first headline"))),
+            Response(
+                _rss(
+                    ("3", "Routine update"),
+                    ("2", "Breaking: second headline"),
+                    ("1", "Breaking: first headline"),
+                )
+            ),
+        ],
+    )
+
+    assert watcher.poll() == []
+    result = watcher.poll()
+
+    assert [entry.title for entry in result] == ["Breaking: second headline"]
+
+
+def test_cross_source_headline_dedup_ignores_breaking_prefix_and_punctuation(
+    monkeypatch, tmp_path
+):
+    sources = [
+        BreakingSource("https://one.test/rss", match="all"),
+        BreakingSource("https://two.test/rss", match="all"),
+    ]
+    watcher = _watcher(
+        monkeypatch,
+        tmp_path,
+        sources,
+        [
+            Response(_rss(("1", "Old one"))),
+            Response(_rss(("1", "Old two"))),
+            Response(_rss(("2", "BREAKING: Major event!"), ("1", "Old one"))),
+            Response(_rss(("2", "Major event"), ("1", "Old two"))),
+        ],
+    )
+    watcher.poll()
+
+    result = watcher.poll()
+
+    assert len(result) == 1
+    first = headline_fingerprint("BREAKING: Major event!")
+    second = headline_fingerprint("Major event")
+    assert first == second
+
+
+def test_conditional_get_validators_and_304(monkeypatch, tmp_path):
+    source = BreakingSource("https://news.test/rss")
+    watcher = _watcher(
+        monkeypatch,
+        tmp_path,
+        [source],
+        [
+            Response(
+                _rss(("1", "Old")),
+                headers={"ETag": '"v1"', "Last-Modified": "yesterday"},
+            ),
+            Response(status=304),
+        ],
+    )
+
+    watcher.poll()
+    assert watcher.poll() == []
+    headers = watcher.session.requests[1][2]
+    assert headers["If-None-Match"] == '"v1"'
+    assert headers["If-Modified-Since"] == "yesterday"
+    assert headers["User-Agent"].startswith("rpi-waiting-time-display/")
+    assert watcher.session.requests[1][3] is True
+
+
+def test_oversized_feed_fails_closed(monkeypatch, tmp_path):
+    monkeypatch.setenv("breaking_news_max_feed_bytes", "1024")
+    source = BreakingSource("https://news.test/private?token=secret")
+    watcher = _watcher(monkeypatch, tmp_path, [source], [Response(b"x" * 1025)])
+
+    assert watcher.poll() == []
+    assert not (tmp_path / "state.json").exists()


### PR DESCRIPTION
## Summary

- add a private-configured RSS/Atom breaking-news watcher with baseline-first detection, freshness checks, bounded persistent state, and cross-source headline deduplication
- add a high-contrast 2.13-inch e-paper card and a non-exclusive four-minute screen claim that yields to higher-priority overrides
- add conditional HTTP polling, request identification, response-size limits, redacted failure logs, offline-safe behavior, tests, and source/licensing guidance

## Source policy

The module does not scrape sites or ship unverified feeds. Documentation includes the verified official BBC headline RSS URL. AP is documented only as an authenticated option for entitled Media API customers. CNN and Reuters remain configurable only when the operator has a publisher-provided or licensed RSS/Atom URL.

## Validation

- `uv run --with-requirements requirements.dev.txt black --check breaking_news_*.py tests/test_breaking_news_*.py`
- `uv run --with-requirements requirements.dev.txt flake8 breaking_news_*.py tests/test_breaking_news_*.py`
- `DYLD_LIBRARY_PATH=/opt/homebrew/lib uv run --with-requirements requirements.dev.txt --with niquests --with cairosvg pytest -q` (236 passed)
- `git diff --check`