### PR TITLE
Add cumulative line to Codex month view

### DIFF
--- a/docs/token-usage-display.md
+++ b/docs/token-usage-display.md
@@ -6,9 +6,10 @@ title: Token usage display
 # Token usage display
 
 The optional token mode rotates between a month-to-date usage-value chart and
-remaining-capacity bars for a five-hour and weekly window. It is disabled by
-default and does not change existing installations until
-`token_usage_enabled=true` is configured.
+remaining-capacity bars for a five-hour and weekly window. The month view pairs
+daily bars with a cumulative line and shows both today's estimate and the
+month-to-date total. It is disabled by default and does not change existing
+installations until `token_usage_enabled=true` is configured.
 
 When a live limit resets, the normal rotation is temporarily replaced by a
 distinct capacity-restored screen. No extra collector field is required: the

--- a/tests/test_token_display.py
+++ b/tests/test_token_display.py
@@ -1,3 +1,5 @@
+from itertools import pairwise
+
 from PIL import Image, ImageChops, ImageDraw
 
 from display_adapter import MockDisplay
@@ -59,9 +61,17 @@ def test_month_view_cumulative_line_runs_from_chart_origin_to_top_right():
 
     assert points[0] == (7, 109)
     assert points[-1] == (243, 73)
-    assert all(
-        current[1] <= previous[1] for previous, current in zip(points, points[1:])
-    )
+    assert all(current[1] <= previous[1] for previous, current in pairwise(points))
+
+
+def test_month_view_cumulative_line_stays_aligned_across_31_days():
+    payload = {**SAMPLE, "daily": SAMPLE["daily"] * 15 + SAMPLE["daily"][:1]}
+    snapshot = TokenUsageSnapshot.from_dict(payload)
+
+    points = _cumulative_points(snapshot.daily, 7, 73, 243, 109)
+
+    assert len(points) == 32
+    assert points[-1] == (243, 73)
 
 
 def test_month_view_uses_snapshot_date_for_today_total():

--- a/tests/test_token_display.py
+++ b/tests/test_token_display.py
@@ -1,16 +1,17 @@
 from PIL import Image, ImageChops, ImageDraw
 
 from display_adapter import MockDisplay
+from tests.test_token_usage import SAMPLE
 from token_display import (
+    _cumulative_points,
     _fonts,
     _reset_badge,
+    _today_cost,
     draw_month_usage,
     draw_usage_limits,
     draw_usage_reset,
 )
 from token_usage import TokenUsageSnapshot
-
-from tests.test_token_usage import SAMPLE
 
 
 def test_token_views_render_at_display_dimensions(monkeypatch, tmp_path):
@@ -49,3 +50,21 @@ def test_reset_badge_is_clipped_into_top_right_corner():
 
     assert image.getpixel((249, 1)) == 0
     assert image.getpixel((226, 1)) == 1
+
+
+def test_month_view_cumulative_line_runs_from_chart_origin_to_top_right():
+    snapshot = TokenUsageSnapshot.from_dict(SAMPLE)
+
+    points = _cumulative_points(snapshot.daily, 7, 73, 243, 109)
+
+    assert points[0] == (7, 109)
+    assert points[-1] == (243, 73)
+    assert all(
+        current[1] <= previous[1] for previous, current in zip(points, points[1:])
+    )
+
+
+def test_month_view_uses_snapshot_date_for_today_total():
+    snapshot = TokenUsageSnapshot.from_dict(SAMPLE)
+
+    assert _today_cost(snapshot) == 83.5

--- a/token_display.py
+++ b/token_display.py
@@ -108,6 +108,20 @@ def _today_cost(snapshot: TokenUsageSnapshot) -> float:
     )
 
 
+def _chart_slots(count: int, left: int, right: int):
+    if count <= 0:
+        return []
+    gap = 2 if count <= 16 else 1
+    span = right - left
+    return [
+        (
+            round(left + span * index / count),
+            round(left + span * (index + 1) / count) - gap,
+        )
+        for index in range(count)
+    ]
+
+
 def _cumulative_points(days, left: int, top: int, right: int, bottom: int):
     if not days:
         return []
@@ -117,10 +131,10 @@ def _cumulative_points(days, left: int, top: int, right: int, bottom: int):
         running_total += max(0, day.cost_usd)
         cumulative.append(running_total)
     maximum = cumulative[-1] or 1
-    x_step = (right - left) / len(days)
+    slots = _chart_slots(len(days), left, right)
     return [(left, bottom)] + [
         (
-            round(left + x_step * (index + 1)),
+            slots[index + 1][0] if index + 1 < len(slots) else right,
             round(bottom - (bottom - top) * value / maximum),
         )
         for index, value in enumerate(cumulative)
@@ -149,13 +163,12 @@ def draw_month_usage(epd, snapshot: TokenUsageSnapshot, set_base_image: bool = F
     )
     if days:
         maximum = max(day.cost_usd for day in days) or 1
-        gap = 2 if len(days) <= 16 else 1
-        width = max(2, (chart_right - chart_left - gap * (len(days) - 1)) // len(days))
-        for index, day in enumerate(days):
+        for day, (left, right) in zip(
+            days, _chart_slots(len(days), chart_left, chart_right)
+        ):
             height = max(1, round((chart_bottom - chart_top) * day.cost_usd / maximum))
-            x = chart_left + index * (width + gap)
             draw.rectangle(
-                (x, chart_bottom - height, x + width - 1, chart_bottom - 1), fill=black
+                (left, chart_bottom - height, right, chart_bottom - 1), fill=black
             )
         cumulative = _cumulative_points(
             days, chart_left, chart_top, chart_right, chart_bottom

--- a/token_display.py
+++ b/token_display.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import os
 from datetime import datetime
+
 from PIL import Image, ImageDraw, ImageFont
 
 from display_adapter import return_display_lock
@@ -99,6 +100,33 @@ def _compact_tokens(value: int) -> str:
     return str(value)
 
 
+def _today_cost(snapshot: TokenUsageSnapshot) -> float:
+    snapshot_date = snapshot.generated_at[:10]
+    return next(
+        (day.cost_usd for day in reversed(snapshot.daily) if day.date == snapshot_date),
+        0,
+    )
+
+
+def _cumulative_points(days, left: int, top: int, right: int, bottom: int):
+    if not days:
+        return []
+    cumulative = []
+    running_total = 0
+    for day in days:
+        running_total += max(0, day.cost_usd)
+        cumulative.append(running_total)
+    maximum = cumulative[-1] or 1
+    x_step = (right - left) / len(days)
+    return [(left, bottom)] + [
+        (
+            round(left + x_step * (index + 1)),
+            round(bottom - (bottom - top) * value / maximum),
+        )
+        for index, value in enumerate(cumulative)
+    ]
+
+
 def draw_month_usage(epd, snapshot: TokenUsageSnapshot, set_base_image: bool = False):
     image, draw, black, white = _canvas(epd)
     fonts = _fonts()
@@ -107,6 +135,9 @@ def draw_month_usage(epd, snapshot: TokenUsageSnapshot, set_base_image: bool = F
 
     draw.text((7, 31), f"${snapshot.month_cost_usd:,.0f}", font=number, fill=black)
     draw.text((7, 58), "MONTH TO DATE", font=micro, fill=black)
+    today_text = f"TODAY ${_today_cost(snapshot):,.0f}"
+    today_width = draw.textbbox((0, 0), today_text, font=micro)[2]
+    draw.text((243 - today_width, 58), today_text, font=micro, fill=black)
     token_text = f"{_compact_tokens(snapshot.month_tokens)} TOKENS"
     token_width = draw.textbbox((0, 0), token_text, font=tiny)[2]
     draw.text((243 - token_width, 38), token_text, font=tiny, fill=black)
@@ -126,6 +157,11 @@ def draw_month_usage(epd, snapshot: TokenUsageSnapshot, set_base_image: bool = F
             draw.rectangle(
                 (x, chart_bottom - height, x + width - 1, chart_bottom - 1), fill=black
             )
+        cumulative = _cumulative_points(
+            days, chart_left, chart_top, chart_right, chart_bottom
+        )
+        draw.line(cumulative, fill=white, width=4, joint="curve")
+        draw.line(cumulative, fill=black, width=2, joint="curve")
         first = days[0].date[-2:].lstrip("0")
         last = days[-1].date[-2:].lstrip("0")
         draw.text((chart_left, 109), first, font=micro, fill=black)


### PR DESCRIPTION
## Summary
- overlay a cumulative month-to-date line on the existing daily usage bars
- show today’s estimated API value beside the month-to-date label
- document and test the combined chart behavior

## Validation
- `DYLD_FALLBACK_LIBRARY_PATH=/opt/homebrew/lib uv run --with-requirements requirements.dev.txt --with cairosvg --with niquests pytest -q` (280 passed)
- rendered and inspected the 250x122 mock display output
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a “TODAY” cost figure to the monthly usage view.
  * Replaced daily cost bars with a cumulative line chart for clearer usage trends.

* **Documentation**
  * Improved formatting in the documentation for the optional monthly token usage mode.

* **Tests**
  * Added coverage for monthly chart rendering and today’s cost calculation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->