### PR TITLE
Exclude sports from breaking-news alerts

### DIFF
--- a/breaking_news_service.py
+++ b/breaking_news_service.py
@@ -121,7 +121,7 @@ def is_sports_entry(entry: FeedEntry) -> bool:
     path_parts = {part.casefold() for part in link.path.split("/") if part}
     if path_parts.intersection({"sport", "sports"}):
         return True
-    if "sport" in entry.publication.casefold().split():
+    if {"sport", "sports"}.intersection(entry.publication.casefold().split()):
         return True
     sport_categories = {
         "sport",
@@ -134,6 +134,7 @@ def is_sports_entry(entry: FeedEntry) -> bool:
         "golf",
         "formula 1",
         "motorsport",
+        "motorsports",
     }
     return any(category.casefold() in sport_categories for category in entry.categories)
 

--- a/breaking_news_service.py
+++ b/breaking_news_service.py
@@ -37,6 +37,7 @@ class BreakingSource:
     match: str = "keywords"
     keywords: tuple[str, ...] = DEFAULT_KEYWORDS
     headers: tuple[tuple[str, str], ...] = ()
+    exclude_sports: bool = True
 
 
 def _source_from_dict(value) -> Optional[BreakingSource]:
@@ -66,6 +67,10 @@ def _source_from_dict(value) -> Optional[BreakingSource]:
     ):
         logger.warning("Ignoring breaking-news source with invalid headers")
         return None
+    exclude_sports = value.get("exclude_sports", True)
+    if not isinstance(exclude_sports, bool):
+        logger.warning("Ignoring breaking-news source with invalid exclude_sports")
+        return None
     label = value.get("label")
     return BreakingSource(
         url=url.strip(),
@@ -73,6 +78,7 @@ def _source_from_dict(value) -> Optional[BreakingSource]:
         match=match,
         keywords=tuple(item.strip().casefold() for item in keywords if item.strip()),
         headers=tuple(headers.items()),
+        exclude_sports=exclude_sports,
     )
 
 
@@ -106,6 +112,30 @@ def headline_fingerprint(title: str) -> str:
 def _safe_source_name(url: str) -> str:
     parsed = urlsplit(url)
     return parsed.hostname or "configured source"
+
+
+def is_sports_entry(entry: FeedEntry) -> bool:
+    """Use explicit feed/link metadata; avoid guessing from headline wording."""
+
+    link = urlsplit(entry.link)
+    path_parts = {part.casefold() for part in link.path.split("/") if part}
+    if path_parts.intersection({"sport", "sports"}):
+        return True
+    if "sport" in entry.publication.casefold().split():
+        return True
+    sport_categories = {
+        "sport",
+        "sports",
+        "football",
+        "soccer",
+        "rugby",
+        "cricket",
+        "tennis",
+        "golf",
+        "formula 1",
+        "motorsport",
+    }
+    return any(category.casefold() in sport_categories for category in entry.categories)
 
 
 class BreakingNewsWatcher:
@@ -255,6 +285,7 @@ class BreakingNewsWatcher:
                     if (
                         entry.key not in previous
                         and fingerprint not in known_fingerprints
+                        and not (source.exclude_sports and is_sports_entry(entry))
                         and self._qualifies(entry, source)
                         and self._fresh(entry)
                     ):

--- a/docs/breaking-news-display.md
+++ b/docs/breaking-news-display.md
@@ -16,7 +16,8 @@ another private path):
   {
     "url": "https://feeds.bbci.co.uk/news/rss.xml",
     "label": "BBC News",
-    "match": "keywords"
+    "match": "keywords",
+    "exclude_sports": true
   },
   {
     "url": "https://licensed-provider.example/breaking.xml",
@@ -32,6 +33,10 @@ another private path):
 `news alert`, and `developing`. Override it per source when the publisher uses
 different labels. Use `match: "all"` only for a feed whose publisher defines
 every item as breaking; using it on a general news feed creates false alerts.
+Sport is excluded by default using explicit feed categories, publication names,
+and `/sport` or `/sports` link paths. This keeps BBC Sport stories in the BBC
+headline feed from claiming the display without making fragile guesses from
+headline words. Set `"exclude_sports": false` on a source to opt back in.
 
 BBC publishes an official headline RSS feed at the URL shown above. AP offers
 authenticated feeds and RSS products to entitled Media API customers; use only

--- a/rss_service.py
+++ b/rss_service.py
@@ -99,6 +99,7 @@ class FeedEntry:
     handle: str = ""
     avatar_url: str = ""
     published: Optional[datetime] = None
+    categories: tuple[str, ...] = ()
 
 
 def configured_sources() -> list[FeedSource]:
@@ -156,6 +157,12 @@ def parse_feed(content: bytes, source: FeedSource) -> list[FeedEntry]:
         )
         key = hashlib.sha256(f"{source.url}|{identity}".encode()).hexdigest()
         published = _parse_date(_text(node, "pubdate", "published", "updated", "date"))
+        categories = tuple(
+            category
+            for child in node
+            if _local_name(child.tag) in {"category", "subject"}
+            if (category := clean_text("".join(child.itertext())))
+        )
         parsed.append(
             FeedEntry(
                 key=key,
@@ -168,6 +175,7 @@ def parse_feed(content: bytes, source: FeedSource) -> list[FeedEntry]:
                 handle=source.handle,
                 avatar_url=urljoin(source.url, avatar_url),
                 published=published,
+                categories=categories,
             )
         )
     return parsed

--- a/rss_service.py
+++ b/rss_service.py
@@ -160,7 +160,8 @@ def parse_feed(content: bytes, source: FeedSource) -> list[FeedEntry]:
         categories = tuple(
             category
             for child in node
-            if _local_name(child.tag) in {"category", "subject"}
+            if isinstance(child.tag, str)
+            and _local_name(child.tag) in {"category", "subject"}
             if (category := clean_text("".join(child.itertext())))
         )
         parsed.append(

--- a/rss_service.py
+++ b/rss_service.py
@@ -162,7 +162,11 @@ def parse_feed(content: bytes, source: FeedSource) -> list[FeedEntry]:
             for child in node
             if isinstance(child.tag, str)
             and _local_name(child.tag) in {"category", "subject"}
-            if (category := clean_text("".join(child.itertext())))
+            if (
+                category := clean_text(
+                    child.attrib.get("term", "") or "".join(child.itertext())
+                )
+            )
         )
         parsed.append(
             FeedEntry(

--- a/tests/test_breaking_news_service.py
+++ b/tests/test_breaking_news_service.py
@@ -7,7 +7,9 @@ from breaking_news_service import (
     BreakingSource,
     configured_breaking_sources,
     headline_fingerprint,
+    is_sports_entry,
 )
+from rss_service import FeedEntry
 
 
 def _rss(*items):
@@ -125,6 +127,80 @@ def test_keyword_normalization_uses_unicode_case_folding(monkeypatch, tmp_path):
     monkeypatch.setenv("breaking_news_config_file", str(path))
 
     assert configured_breaking_sources()[0].keywords == ("strasse",)
+
+
+def test_sport_exclusion_defaults_on_and_can_be_disabled(monkeypatch, tmp_path):
+    path = tmp_path / "feeds.json"
+    path.write_text(
+        json.dumps(
+            [
+                {"url": "https://one.test/feed"},
+                {"url": "https://two.test/feed", "exclude_sports": False},
+            ]
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("breaking_news_config_file", str(path))
+
+    sources = configured_breaking_sources()
+
+    assert sources[0].exclude_sports is True
+    assert sources[1].exclude_sports is False
+
+
+def test_bbc_sport_link_and_feed_category_are_sports():
+    bbc = FeedEntry(
+        "bbc",
+        "https://feeds.bbci.co.uk/news/rss.xml",
+        "breaking",
+        "BBC News",
+        "Breaking: transfer confirmed",
+        link="https://www.bbc.com/sport/football/articles/example",
+    )
+    category = FeedEntry(
+        "wire",
+        "https://wire.test/rss",
+        "breaking",
+        "Wire",
+        "Breaking: final result",
+        categories=("Sport",),
+    )
+
+    assert is_sports_entry(bbc)
+    assert is_sports_entry(category)
+
+
+def test_non_sport_bbc_breaking_story_is_not_filtered():
+    entry = FeedEntry(
+        "bbc",
+        "https://feeds.bbci.co.uk/news/rss.xml",
+        "breaking",
+        "BBC News",
+        "Breaking: government announces policy",
+        link="https://www.bbc.com/news/articles/example",
+    )
+
+    assert not is_sports_entry(entry)
+
+
+def test_poll_suppresses_new_bbc_sport_item(monkeypatch, tmp_path):
+    baseline = _rss(("1", "Breaking: initial story"))
+    updated = b"""<rss><channel><title>BBC News</title>
+      <item><title>Breaking: cup final result</title><guid>sport-2</guid>
+        <link>https://www.bbc.com/sport/football/articles/example</link>
+        <pubDate>Sat, 11 Jul 2026 10:00:00 GMT</pubDate></item>
+      <item><title>Breaking: initial story</title><guid>1</guid>
+        <pubDate>Sat, 11 Jul 2026 10:00:00 GMT</pubDate></item>
+    </channel></rss>"""
+    watcher = _watcher(
+        monkeypatch,
+        tmp_path,
+        [BreakingSource("https://feeds.bbci.co.uk/news/rss.xml")],
+        [Response(baseline), Response(updated)],
+    )
+
+    assert watcher.poll() == []
+    assert watcher.poll() == []
 
 
 def test_first_poll_baselines_then_only_new_matching_headline_is_returned(

--- a/tests/test_breaking_news_service.py
+++ b/tests/test_breaking_news_service.py
@@ -165,9 +165,26 @@ def test_bbc_sport_link_and_feed_category_are_sports():
         "Breaking: final result",
         categories=("Sport",),
     )
+    plural_publication = FeedEntry(
+        "sports-wire",
+        "https://wire.test/rss",
+        "breaking",
+        "Example Sports",
+        "Breaking: final result",
+    )
+    plural_category = FeedEntry(
+        "motorsports",
+        "https://wire.test/rss",
+        "breaking",
+        "Wire",
+        "Breaking: race result",
+        categories=("Motorsports",),
+    )
 
     assert is_sports_entry(bbc)
     assert is_sports_entry(category)
+    assert is_sports_entry(plural_publication)
+    assert is_sports_entry(plural_category)
 
 
 def test_non_sport_bbc_breaking_story_is_not_filtered():

--- a/tests/test_rss_service.py
+++ b/tests/test_rss_service.py
@@ -70,6 +70,16 @@ def test_feed_with_comments_does_not_crash():
     assert entry.categories == ("News",)
 
 
+def test_atom_feed_parses_category_term_attribute():
+    content = b"""<feed xmlns="http://www.w3.org/2005/Atom">
+      <title>Example</title><entry><title>Update</title><id>one</id>
+      <category term="sports"/></entry></feed>"""
+
+    entry = parse_feed(content, FeedSource("https://news.test/atom"))[0]
+
+    assert entry.categories == ("sports",)
+
+
 def test_configured_sources_builds_nitter_and_arbitrary_feeds(monkeypatch):
     monkeypatch.setenv("rss_nitter_base_url", "http://nitter.local/")
     monkeypatch.setenv("rss_nitter_users", "alice, @bob")

--- a/tests/test_rss_service.py
+++ b/tests/test_rss_service.py
@@ -1,7 +1,6 @@
 from datetime import timezone
 
-from rss_service import (FeedSource, RSSWatcher, configured_sources, env_int,
-                         parse_feed)
+from rss_service import FeedSource, RSSWatcher, configured_sources, env_int, parse_feed
 
 RSS = b"""<?xml version="1.0"?>
 <rss version="2.0" xmlns:dc="http://purl.org/dc/elements/1.1/">
@@ -47,6 +46,17 @@ def test_nitter_feed_parses_identity_text_and_avatar():
     assert entry.title == "Hello & welcome to the feed"
     assert entry.avatar_url == "https://nitter.test/pic/avatar.jpg"
     assert entry.published.tzinfo == timezone.utc
+
+
+def test_feed_parses_category_metadata():
+    content = RSS.replace(
+        b"<guid>tweet-1</guid>",
+        b"<guid>tweet-1</guid><category>Sport</category>",
+    )
+
+    entry = parse_feed(content, FeedSource("https://news.test/rss"))[0]
+
+    assert entry.categories == ("Sport",)
 
 
 def test_configured_sources_builds_nitter_and_arbitrary_feeds(monkeypatch):

--- a/tests/test_rss_service.py
+++ b/tests/test_rss_service.py
@@ -59,6 +59,17 @@ def test_feed_parses_category_metadata():
     assert entry.categories == ("Sport",)
 
 
+def test_feed_with_comments_does_not_crash():
+    content = RSS.replace(
+        b"<guid>tweet-1</guid>",
+        b"<guid>tweet-1</guid><!-- comment --><category>News</category>",
+    )
+
+    entry = parse_feed(content, FeedSource("https://news.test/rss"))[0]
+
+    assert entry.categories == ("News",)
+
+
 def test_configured_sources_builds_nitter_and_arbitrary_feeds(monkeypatch):
     monkeypatch.setenv("rss_nitter_base_url", "http://nitter.local/")
     monkeypatch.setenv("rss_nitter_users", "alice, @bob")


### PR DESCRIPTION
## Summary

- suppress sports items from breaking-news alerts by default using explicit feed categories, publication metadata, and `/sport` or `/sports` link paths
- preserve non-sport BBC breaking alerts without guessing from ambiguous headline words
- allow per-source opt-in with `"exclude_sports": false`
- retain RSS/Atom category metadata for classification and add regression coverage/documentation

## Validation

- focused breaking-news/RSS/arbiter suite: 32 passed
- full repository suite: 286 passed
- Black clean on changed Python files
- Flake8 clean on changed files with the repository existing `E501,W503` compatibility exclusions
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Sports-related breaking news is now excluded by default from configured feeds.
  - Feed entries now recognize category metadata to improve sports detection.
  - Sports filtering can be disabled per feed with the `exclude_sports` setting.

- **Documentation**
  - Added configuration guidance and examples for controlling sports-news filtering.

- **Bug Fixes**
  - Improved filtering of sports headlines based on feed categories, publication details, and links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->