### PR TITLE
Add recurring YNAB glance display

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -220,11 +220,20 @@ ynab_max_stale_seconds=21600
 ynab_view_duration=120
 ynab_views=month,daily,active,funding,exception
 ynab_fallback_mode=transit
+# Optional low-priority glance in the normal information rotation. With the
+# defaults below, YNAB appears for 60 seconds at :15 and :45 each hour.
+ynab_glance_enabled=false
+ynab_glance_poll_seconds=1
+ynab_glance_interval_seconds=1800
+ynab_glance_duration_seconds=60
+ynab_glance_offset_seconds=900
+ynab_glance_priority=20
 ynab_daily_categories=Restaurants,Groceries
 ynab_non_spending_groups=Savings Goals,Investments,Rainy Day Funds
 ynab_funding_categories=Vacation,Drier,New laptop
 
 # First matching entry wins. Optional day selectors include weekdays, weekends,
 # mon-fri, or mon+wed+fri. Ranges may cross midnight. token requires recent
-# Codex activity; token-always only requires fresh data.
-display_schedule=ynab@weekends@09:00-12:00,transit@weekdays@06:00-10:00,token@weekdays@10:00-22:00,weather@weekdays@22:00-06:00
+# Codex activity; token-always only requires fresh data. Fixed ynab windows are
+# supported, but ynab_glance_enabled is preferred for recurring budget glances.
+display_schedule=transit@weekdays@06:00-10:00,token@weekdays@10:00-22:00,weather@weekdays@22:00-06:00

--- a/basic.py
+++ b/basic.py
@@ -45,6 +45,7 @@ from screen_arbiter import ScreenArbiter
 from rss_plugin import RSSPlugin
 from breaking_news_plugin import BreakingNewsPlugin
 from calendar_plugin import CalendarPlugin
+from ynab_plugin import YnabGlancePlugin
 from display_override_api import DisplayOverrideServer
 
 logger = logging.getLogger(__name__)
@@ -366,6 +367,17 @@ class DisplayManager:
             on_render=self._calendar_rendered,
             base_mode_at=self.display_schedule.mode_at,
         )
+        self.ynab_glance_plugin = YnabGlancePlugin(
+            epd,
+            self.screen_arbiter,
+            self._display_lock,
+            client=self.ynab_client,
+            views=self.ynab_views,
+            on_render=self._plugin_rendered,
+            on_release=self._ynab_glance_released,
+            is_current=lambda: self.current_display_mode == YnabGlancePlugin.OWNER,
+            base_mode_at=self.display_schedule.mode_at,
+        )
         self.override_server = DisplayOverrideServer(
             self.request_display_override,
             self.clear_display_override,
@@ -402,8 +414,14 @@ class DisplayManager:
     def _plugin_rendered(self, owner):
         self.current_display_mode = owner
         self.current_token_view = None
+        self.current_ynab_view = None
         self.in_weather_mode = False
         self.last_display_update = datetime.now()
+
+    def _ynab_glance_released(self):
+        if self.screen_arbiter.can_render():
+            self._last_screen_owner = None
+            self._force_display_update()
 
     def _scheduled_mode(self, current_time):
         scheduled_mode = self.display_schedule.mode_at(current_time)
@@ -676,6 +694,7 @@ class DisplayManager:
         # Calendar events are fetched and rendered independently of the base
         # transit/weather/token data sources.
         self.calendar_plugin.start()
+        self.ynab_glance_plugin.start()
         self.override_server.start()
         self.rss_plugin.start()
         self.breaking_news_plugin.start()
@@ -1183,6 +1202,7 @@ class DisplayManager:
 
         self.override_server.stop()
         self.calendar_plugin.stop()
+        self.ynab_glance_plugin.stop()
         self.rss_plugin.stop()
         self.breaking_news_plugin.stop()
             

--- a/docs/screen-arbiter.md
+++ b/docs/screen-arbiter.md
@@ -1,8 +1,8 @@
 # Screen ownership arbiter
 
-The scheduled transit, weather, or token screen is the base display. Optional
-plugins must claim the screen through `ScreenArbiter` before rendering an
-interrupting view.
+The scheduled transit, weather, token, or fixed-window YNAB screen is the base
+display. Optional plugins must claim the screen through `ScreenArbiter` before
+rendering an interrupting view.
 
 A claim has four properties:
 
@@ -33,6 +33,12 @@ Flights default to priority `50`. ISS defaults to `60` when the existing
 
 Future plugins should use bounded claims and check `can_render(owner)` again
 while holding the display lock immediately before writing to the device.
+
+Recurring calendar agenda and YNAB glances both default to priority `20`. Their
+default cadences are offset: calendar appears around `:00` and `:30`, while YNAB
+appears around `:15` and `:45`. Both claims are bounded and non-exclusive, so
+higher-priority information interrupts them and the scheduled base display
+returns afterward.
 
 The RSS watcher defaults to priority `30`: it interrupts the scheduled base
 screen and calendar agenda glances, but yields to upcoming calendar events,

--- a/docs/ynab-display.md
+++ b/docs/ynab-display.md
@@ -12,13 +12,32 @@ ynab_currency_symbol=€
 ynab_views=month,daily,active,funding,exception
 ynab_daily_categories=Restaurants,Groceries
 ynab_funding_categories=Vacation,Drier,New laptop
-display_schedule=ynab@weekends@09:00-12:00,transit@00:00-00:00
+
+ynab_glance_enabled=true
+ynab_glance_poll_seconds=1
+ynab_glance_interval_seconds=1800
+ynab_glance_duration_seconds=60
+ynab_glance_offset_seconds=900
+ynab_glance_priority=20
 ```
 
-`ynab` and `ynab-always` are schedule modes. Both show the latest current-month
-snapshot; `ynab-always` is provided for consistency with the token display.
-When YNAB is unavailable, `ynab_fallback_mode` is used. A recent last-good
-snapshot may be shown with a `STALE` header.
+The glance settings add YNAB to the normal information flow without reserving a
+fixed clock-time block in `display_schedule`. With the values above, a YNAB view
+appears for 60 seconds at `:15` and `:45` each hour. Successive appearances
+advance through the configured `ynab_views`. The 15-minute offset avoids the
+calendar agenda's default `:00` and `:30` cadence.
+
+YNAB glances use a low-priority, non-exclusive screen claim. Upcoming calendar
+events, RSS entries, flights, ISS passes, breaking news, and display overrides
+can interrupt them. The normal scheduled base display is restored after the
+claim ends. If YNAB has no usable snapshot, the glance is skipped; a recent
+last-good snapshot may be shown with a `STALE` header.
+
+For intentionally fixed YNAB periods, `ynab` and `ynab-always` remain supported
+`display_schedule` modes. Both show the latest current-month snapshot;
+`ynab-always` is provided for consistency with the token display. A recurring
+glance is suppressed while either fixed YNAB mode is already scheduled. When a
+fixed YNAB period is unavailable, `ynab_fallback_mode` is used.
 
 ## Calculation policy
 

--- a/readme.md
+++ b/readme.md
@@ -10,7 +10,7 @@ A Raspberry Pi project that displays bus waiting times using an e-Paper display 
 - ✈️ Optional: Overhead flight tracking
 - 🛰️ Optional: ISS tracking when visible
 - 📊 Optional: Scheduled token-usage dashboards with month-to-date estimates and remaining-capacity bars
-- 💶 Optional: Read-only YNAB views based only on the current month's assignments
+- 💶 Optional: Recurring read-only YNAB glances based only on the current month's assignments
 - 📅 Optional calendar plugin with upcoming-event alerts and agenda glances
 - 📰 Optional RSS/Nitter plugin with compact new-entry notifications
 - 🎛️ Screen arbitration, weekday-aware schedules, and a private-network display override API
@@ -19,9 +19,9 @@ A Raspberry Pi project that displays bus waiting times using an e-Paper display 
 
 ## Optional Display Plugins
 
-The calendar and RSS plugins share the screen safely with transit, weather,
-flight, ISS, and Codex views through the screen arbiter. Each plugin is disabled
-by default and configured in the untracked `.env` file.
+The calendar, YNAB glance, and RSS plugins share the screen safely with
+transit, weather, flight, ISS, and Codex views through the screen arbiter. Each
+plugin is disabled by default and configured in the untracked `.env` file.
 
 ### Calendar
 
@@ -65,8 +65,9 @@ documentation.
 ### YNAB monthly budget views
 
 YNAB screens distinguish current-month spending permission from historical
-rollover. They never treat Ready to Assign as safe-to-spend money. See the
-[configuration and calculation policy](docs/ynab-display.md).
+rollover. They can appear as low-priority recurring glances without replacing
+the normal scheduled display, and never treat Ready to Assign as safe-to-spend
+money. See the [configuration and calculation policy](docs/ynab-display.md).
 
 | Monthly plan | Daily allowance | Active envelopes |
 |---|---|---|

--- a/tests/test_ynab_budget.py
+++ b/tests/test_ynab_budget.py
@@ -1,5 +1,6 @@
 import json
 import threading
+import time
 from datetime import datetime
 
 from ynab_budget import (
@@ -109,6 +110,37 @@ def test_concurrent_snapshot_requests_share_one_refresh(monkeypatch, tmp_path):
     assert request_count == 1
     assert len(results) == 2
     assert results[0] is results[1]
+
+
+def test_cached_snapshot_remains_readable_during_forced_refresh(monkeypatch, tmp_path):
+    monkeypatch.setenv("ynab_enabled", "true")
+    monkeypatch.setenv("ynab_cache_file", str(tmp_path / "ynab.json"))
+    client = YnabBudgetClient()
+    cached = client._snapshot = YnabSnapshot.from_dict(client._normalize(RAW))
+    client._last_fetch_monotonic = time.monotonic()
+    request_started = threading.Event()
+    release_request = threading.Event()
+
+    def request():
+        request_started.set()
+        assert release_request.wait(timeout=2)
+        return RAW
+
+    monkeypatch.setattr(client, "_request", request)
+    refresh = threading.Thread(target=lambda: client.get_snapshot(force=True))
+    refresh.start()
+    assert request_started.wait(timeout=2)
+
+    result = []
+    reader = threading.Thread(target=lambda: result.append(client.get_snapshot()))
+    reader.start()
+    reader.join(timeout=0.2)
+
+    assert not reader.is_alive()
+    assert result == [cached]
+    release_request.set()
+    refresh.join(timeout=2)
+    assert not refresh.is_alive()
 
 
 def test_failed_refresh_is_throttled_without_cached_snapshot(monkeypatch, tmp_path):

--- a/tests/test_ynab_budget.py
+++ b/tests/test_ynab_budget.py
@@ -1,8 +1,13 @@
 import json
+import threading
 from datetime import datetime
 
-from ynab_budget import (YnabBudgetClient, YnabSnapshot, configured_views,
-                         view_at)
+from ynab_budget import (
+    YnabBudgetClient,
+    YnabSnapshot,
+    configured_views,
+    view_at,
+)
 
 RAW = {
     "data": {
@@ -50,9 +55,11 @@ def test_client_uses_last_good_cache_when_refresh_fails(monkeypatch, tmp_path):
     client = YnabBudgetClient()
     normalized = client._normalize(RAW)
     client.cache_file.write_text(json.dumps(normalized))
-    monkeypatch.setattr(
-        client, "_request", lambda: (_ for _ in ()).throw(OSError("offline"))
-    )
+
+    def fail_request():
+        raise OSError("offline")
+
+    monkeypatch.setattr(client, "_request", fail_request)
     snapshot = client.get_snapshot(force=True)
     assert snapshot is not None
     assert snapshot.stale is True
@@ -64,3 +71,59 @@ def test_views_are_filtered_and_rotate(monkeypatch):
     assert configured_views() == ["daily", "active"]
     assert view_at(datetime.fromtimestamp(0), ["daily", "active"]) == "daily"
     assert view_at(datetime.fromtimestamp(60), ["daily", "active"]) == "active"
+
+
+def test_concurrent_snapshot_requests_share_one_refresh(monkeypatch, tmp_path):
+    monkeypatch.setenv("ynab_enabled", "true")
+    monkeypatch.setenv("ynab_cache_file", str(tmp_path / "ynab.json"))
+    client = YnabBudgetClient()
+    request_started = threading.Event()
+    release_request = threading.Event()
+    request_count = 0
+
+    def request():
+        nonlocal request_count
+        request_count += 1
+        request_started.set()
+        assert release_request.wait(timeout=2)
+        return RAW
+
+    monkeypatch.setattr(client, "_request", request)
+    results = []
+
+    def get_snapshot():
+        results.append(client.get_snapshot())
+
+    first = threading.Thread(target=get_snapshot)
+    second = threading.Thread(target=get_snapshot)
+
+    first.start()
+    assert request_started.wait(timeout=2)
+    second.start()
+    release_request.set()
+    first.join(timeout=2)
+    second.join(timeout=2)
+
+    assert not first.is_alive()
+    assert not second.is_alive()
+    assert request_count == 1
+    assert len(results) == 2
+    assert results[0] is results[1]
+
+
+def test_failed_refresh_is_throttled_without_cached_snapshot(monkeypatch, tmp_path):
+    monkeypatch.setenv("ynab_enabled", "true")
+    monkeypatch.setenv("ynab_cache_file", str(tmp_path / "missing.json"))
+    client = YnabBudgetClient()
+    request_count = 0
+
+    def fail_request():
+        nonlocal request_count
+        request_count += 1
+        raise OSError("offline")
+
+    monkeypatch.setattr(client, "_request", fail_request)
+
+    assert client.get_snapshot() is None
+    assert client.get_snapshot() is None
+    assert request_count == 1

--- a/tests/test_ynab_plugin.py
+++ b/tests/test_ynab_plugin.py
@@ -1,0 +1,238 @@
+import threading
+from datetime import datetime, timedelta
+from types import SimpleNamespace
+
+from screen_arbiter import ScreenArbiter
+from ynab_budget import YnabSnapshot
+from ynab_plugin import YnabGlancePlugin
+
+
+def _snapshot(*, stale=False, generated_at="2026-07-12T08:00:00+02:00"):
+    return YnabSnapshot(
+        generated_at=generated_at,
+        month="2026-07-01",
+        currency_symbol="€",
+        categories=[],
+        stale=stale,
+    )
+
+
+def _plugin(
+    monkeypatch,
+    rendered,
+    *,
+    enabled=True,
+    base_mode_at=None,
+    lock=None,
+    on_release=None,
+    is_current=None,
+):
+    monkeypatch.setenv("ynab_glance_enabled", "true" if enabled else "false")
+    monkeypatch.setenv("ynab_glance_poll_seconds", "1")
+    monkeypatch.setenv("ynab_glance_interval_seconds", "1800")
+    monkeypatch.setenv("ynab_glance_duration_seconds", "60")
+    monkeypatch.setenv("ynab_glance_offset_seconds", "900")
+    monkeypatch.setenv("ynab_glance_priority", "20")
+    monkeypatch.setattr(
+        "ynab_plugin.draw_ynab_view",
+        lambda epd, snapshot, view, **kwargs: rendered.append(
+            (snapshot, view, kwargs)
+        ),
+    )
+    client = SimpleNamespace(enabled=True, get_snapshot=lambda: _snapshot())
+    return YnabGlancePlugin(
+        object(),
+        ScreenArbiter(),
+        lock or threading.Lock(),
+        client=client,
+        views=["month", "daily", "active", "funding", "exception"],
+        on_release=on_release,
+        is_current=is_current,
+        base_mode_at=base_mode_at or (lambda now: "transit"),
+    )
+
+
+def test_disabled_plugin_does_not_start_or_claim(monkeypatch):
+    plugin = _plugin(monkeypatch, [], enabled=False)
+
+    plugin.start()
+    plugin.tick(datetime(2026, 7, 12, 8, 15), _snapshot())
+
+    assert plugin._thread is None
+    assert plugin.arbiter.active_owner() is None
+
+
+def test_glance_claims_at_offset_and_releases_after_duration(monkeypatch):
+    rendered = []
+    plugin = _plugin(monkeypatch, rendered)
+    start = datetime(2026, 7, 12, 8, 15)
+
+    plugin.tick(start, _snapshot())
+
+    claim = plugin.arbiter.claim_for(plugin.OWNER)
+    assert claim.priority == 20
+    assert claim.exclusive is False
+    assert rendered[0][2]["set_base_image"] is True
+
+    plugin.tick(start + timedelta(seconds=60), _snapshot())
+    assert plugin.arbiter.active_owner() is None
+
+
+def test_glance_is_offset_from_calendar_cadence(monkeypatch):
+    plugin = _plugin(monkeypatch, [])
+
+    assert not plugin._is_due(datetime(2026, 7, 12, 8, 0))
+    assert plugin._is_due(datetime(2026, 7, 12, 8, 15))
+    assert not plugin._is_due(datetime(2026, 7, 12, 8, 16))
+    assert plugin._is_due(datetime(2026, 7, 12, 8, 45))
+
+
+def test_successive_glances_advance_views_and_wrap(monkeypatch):
+    rendered = []
+    plugin = _plugin(monkeypatch, rendered)
+    start = datetime(2026, 7, 12, 8, 15)
+
+    for index in range(6):
+        now = start + timedelta(minutes=30 * index)
+        plugin.tick(now, _snapshot(generated_at=str(index)))
+        plugin.tick(now + timedelta(seconds=60), _snapshot())
+
+    views = [item[1] for item in rendered]
+    view_indexes = [plugin.views.index(view) for view in views]
+    assert all(
+        current == (previous + 1) % len(plugin.views)
+        for previous, current in zip(view_indexes, view_indexes[1:])
+    )
+    assert views[0] == views[-1]
+
+
+def test_glance_does_not_redraw_unchanged_slot(monkeypatch):
+    rendered = []
+    plugin = _plugin(monkeypatch, rendered)
+    start = datetime(2026, 7, 12, 8, 15)
+    snapshot = _snapshot()
+
+    plugin.tick(start, snapshot)
+    plugin.tick(start + timedelta(seconds=10), snapshot)
+
+    assert len(rendered) == 1
+
+
+def test_glance_redraws_after_higher_priority_preemption(monkeypatch):
+    rendered = []
+    plugin = _plugin(monkeypatch, rendered)
+    start = datetime(2026, 7, 12, 8, 15)
+    snapshot = _snapshot()
+
+    plugin.tick(start, snapshot)
+    assert plugin.arbiter.claim("flight", 50, 30)
+    plugin.tick(start + timedelta(seconds=10), snapshot)
+    plugin.arbiter.release("flight")
+    plugin.tick(start + timedelta(seconds=20), snapshot)
+
+    assert len(rendered) == 2
+    assert rendered[-1][2]["set_base_image"] is True
+
+
+def test_glance_rechecks_ownership_after_acquiring_display_lock(monkeypatch):
+    rendered = []
+    plugin = _plugin(monkeypatch, rendered)
+
+    class PreemptingLock:
+        def __enter__(self):
+            plugin.arbiter.claim("breaking-news", 70, 30)
+
+        def __exit__(self, exc_type, exc_value, traceback):
+            return False
+
+    plugin.display_lock = PreemptingLock()
+    plugin.tick(datetime(2026, 7, 12, 8, 15), _snapshot())
+
+    assert rendered == []
+
+
+def test_stale_snapshot_renders_but_missing_snapshot_releases(monkeypatch):
+    rendered = []
+    plugin = _plugin(monkeypatch, rendered)
+    start = datetime(2026, 7, 12, 8, 15)
+
+    plugin.tick(start, _snapshot(stale=True))
+    assert rendered[0][0].stale is True
+
+    plugin.tick(start + timedelta(seconds=10), None)
+    assert plugin.arbiter.active_owner() is None
+
+
+def test_fixed_ynab_schedule_suppresses_glance(monkeypatch):
+    rendered = []
+    plugin = _plugin(monkeypatch, rendered, base_mode_at=lambda now: "ynab")
+
+    plugin.tick(datetime(2026, 7, 12, 8, 15), _snapshot())
+
+    assert plugin.arbiter.active_owner() is None
+    assert rendered == []
+
+
+def test_stop_releases_active_claim(monkeypatch):
+    plugin = _plugin(monkeypatch, [])
+    plugin.tick(datetime(2026, 7, 12, 8, 15), _snapshot())
+
+    plugin.stop()
+
+    assert plugin.arbiter.active_owner() is None
+
+
+def test_slot_identity_changes_across_dates(monkeypatch):
+    plugin = _plugin(monkeypatch, [])
+    first = datetime(2026, 7, 12, 8, 15)
+    second = first + timedelta(days=1)
+
+    assert plugin._slot_at(first) != plugin._slot_at(second)
+
+
+def test_transient_preemption_redraws_when_pixels_are_no_longer_current(monkeypatch):
+    rendered = []
+    current_owner = [YnabGlancePlugin.OWNER]
+    plugin = _plugin(
+        monkeypatch,
+        rendered,
+        is_current=lambda: current_owner[0] == YnabGlancePlugin.OWNER,
+    )
+    start = datetime(2026, 7, 12, 8, 15)
+    snapshot = _snapshot()
+
+    plugin.tick(start, snapshot)
+    current_owner[0] = "flight"
+    plugin.tick(start + timedelta(seconds=10), snapshot)
+
+    assert len(rendered) == 2
+    assert rendered[-1][2]["set_base_image"] is True
+
+
+def test_releasing_active_glance_requests_base_restoration(monkeypatch):
+    restored = []
+    plugin = _plugin(monkeypatch, [], on_release=lambda: restored.append(True))
+    start = datetime(2026, 7, 12, 8, 15)
+
+    plugin.tick(start, _snapshot())
+    plugin.tick(start + timedelta(seconds=60), _snapshot())
+
+    assert restored == [True]
+
+
+def test_skipped_slot_does_not_consume_next_view(monkeypatch):
+    rendered = []
+    plugin = _plugin(monkeypatch, rendered)
+    first = datetime(2026, 7, 12, 8, 15)
+    skipped = first + timedelta(minutes=30)
+    next_render = skipped + timedelta(minutes=30)
+
+    plugin.tick(first, _snapshot())
+    first_view = rendered[-1][1]
+    plugin.tick(first + timedelta(seconds=60), _snapshot())
+    plugin.tick(skipped, None)
+    plugin.tick(next_render, _snapshot(generated_at="next"))
+
+    assert plugin.views.index(rendered[-1][1]) == (
+        plugin.views.index(first_view) + 1
+    ) % len(plugin.views)

--- a/ynab_budget.py
+++ b/ynab_budget.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+import threading
 import time
 from dataclasses import dataclass
 from datetime import date, datetime
@@ -107,6 +108,7 @@ class YnabBudgetClient:
         )
         self._snapshot: Optional[YnabSnapshot] = None
         self._last_fetch_monotonic = 0.0
+        self._lock = threading.Lock()
 
     def _request(self) -> Dict[str, Any]:
         if not self.access_token:
@@ -175,26 +177,27 @@ class YnabBudgetClient:
     def get_snapshot(self, force: bool = False) -> Optional[YnabSnapshot]:
         if not self.enabled:
             return None
-        if (
-            not force
-            and self._snapshot is not None
-            and time.monotonic() - self._last_fetch_monotonic
-            < self.refresh_interval
-        ):
+        with self._lock:
+            if (
+                not force
+                and self._last_fetch_monotonic
+                and time.monotonic() - self._last_fetch_monotonic
+                < self.refresh_interval
+            ):
+                return self._snapshot
+            try:
+                normalized = self._normalize(self._request())
+                self._write_cache(normalized)
+                self._snapshot = YnabSnapshot.from_dict(normalized)
+            except Exception as exc:
+                # HTTP errors can include the private budget URL. Log only the
+                # exception type and keep identifiers out of service logs.
+                logger.warning(
+                    "YNAB refresh failed (%s); using cache", type(exc).__name__
+                )
+                self._snapshot = self._load_stale()
+            self._last_fetch_monotonic = time.monotonic()
             return self._snapshot
-        try:
-            normalized = self._normalize(self._request())
-            self._write_cache(normalized)
-            self._snapshot = YnabSnapshot.from_dict(normalized)
-        except Exception as exc:
-            # HTTP errors can include the private budget URL. Log only the
-            # exception type and keep identifiers out of service logs.
-            logger.warning(
-                "YNAB refresh failed (%s); using cache", type(exc).__name__
-            )
-            self._snapshot = self._load_stale()
-        self._last_fetch_monotonic = time.monotonic()
-        return self._snapshot
 
 
 def configured_views() -> List[str]:

--- a/ynab_budget.py
+++ b/ynab_budget.py
@@ -109,6 +109,7 @@ class YnabBudgetClient:
         self._snapshot: Optional[YnabSnapshot] = None
         self._last_fetch_monotonic = 0.0
         self._lock = threading.Lock()
+        self._fetch_lock = threading.Lock()
 
     def _request(self) -> Dict[str, Any]:
         if not self.access_token:
@@ -177,7 +178,14 @@ class YnabBudgetClient:
     def get_snapshot(self, force: bool = False) -> Optional[YnabSnapshot]:
         if not self.enabled:
             return None
-        with self._lock:
+        if (
+            not force
+            and self._last_fetch_monotonic
+            and time.monotonic() - self._last_fetch_monotonic
+            < self.refresh_interval
+        ):
+            return self._snapshot
+        with self._fetch_lock:
             if (
                 not force
                 and self._last_fetch_monotonic
@@ -188,16 +196,18 @@ class YnabBudgetClient:
             try:
                 normalized = self._normalize(self._request())
                 self._write_cache(normalized)
-                self._snapshot = YnabSnapshot.from_dict(normalized)
+                snapshot = YnabSnapshot.from_dict(normalized)
             except Exception as exc:
                 # HTTP errors can include the private budget URL. Log only the
                 # exception type and keep identifiers out of service logs.
                 logger.warning(
                     "YNAB refresh failed (%s); using cache", type(exc).__name__
                 )
-                self._snapshot = self._load_stale()
-            self._last_fetch_monotonic = time.monotonic()
-            return self._snapshot
+                snapshot = self._load_stale()
+            with self._lock:
+                self._snapshot = snapshot
+                self._last_fetch_monotonic = time.monotonic()
+            return snapshot
 
 
 def configured_views() -> List[str]:

--- a/ynab_plugin.py
+++ b/ynab_plugin.py
@@ -1,0 +1,186 @@
+"""Recurring YNAB glance backed by the shared screen arbiter."""
+
+from __future__ import annotations
+
+import logging
+import os
+import threading
+from datetime import datetime
+from typing import Callable, List, Optional
+
+from ynab_budget import YnabBudgetClient, YnabSnapshot
+from ynab_display import draw_ynab_view
+
+logger = logging.getLogger(__name__)
+
+
+def _enabled(name: str, default: str = "false") -> bool:
+    return os.getenv(name, default).strip().lower() == "true"
+
+
+class YnabGlancePlugin:
+    OWNER = "ynab-glance"
+
+    def __init__(
+        self,
+        epd,
+        arbiter,
+        display_lock,
+        *,
+        client: YnabBudgetClient,
+        views: List[str],
+        on_render: Optional[Callable[[str], None]] = None,
+        on_release: Optional[Callable[[], None]] = None,
+        is_current: Optional[Callable[[], bool]] = None,
+        base_mode_at: Optional[Callable[[datetime], str]] = None,
+    ):
+        self.epd = epd
+        self.arbiter = arbiter
+        self.display_lock = display_lock
+        self.client = client
+        self.views = views
+        self.on_render = on_render
+        self.on_release = on_release
+        self.is_current = is_current
+        self.base_mode_at = base_mode_at
+        self.enabled = self.client.enabled and _enabled("ynab_glance_enabled")
+        self.poll_seconds = max(1, int(os.getenv("ynab_glance_poll_seconds", "1")))
+        self.claim_ttl = max(5, self.poll_seconds * 3)
+        self.interval = max(
+            0, int(os.getenv("ynab_glance_interval_seconds", "1800"))
+        )
+        configured_duration = max(
+            0, int(os.getenv("ynab_glance_duration_seconds", "60"))
+        )
+        self.duration = min(configured_duration, self.interval) if self.interval else 0
+        configured_offset = int(os.getenv("ynab_glance_offset_seconds", "900"))
+        self.offset = configured_offset % self.interval if self.interval else 0
+        self.priority = int(os.getenv("ynab_glance_priority", "20"))
+        self._next_view_index = 0
+        self._active_slot = None
+        self._active_view = None
+        self._active_view_committed = False
+        self._render_key = None
+        self._was_selected = False
+        self._stop_event = threading.Event()
+        self._thread = None
+
+    def start(self):
+        if not self.enabled:
+            return
+        if self._thread and self._thread.is_alive():
+            return
+        self._thread = None
+        self._stop_event.clear()
+        self._thread = threading.Thread(
+            target=self._run,
+            name="YnabGlancePlugin",
+            daemon=True,
+        )
+        self._thread.start()
+        logger.info("YNAB glance plugin started")
+
+    def stop(self):
+        self._stop_event.set()
+        thread = self._thread
+        if thread:
+            thread.join(timeout=1.0)
+            if not thread.is_alive():
+                self._thread = None
+        self._release(restore=False)
+
+    def _run(self):
+        while not self._stop_event.is_set():
+            try:
+                now = datetime.now()
+                snapshot = self.client.get_snapshot() if self._is_due(now) else None
+                now = datetime.now()
+                if self._stop_event.is_set():
+                    break
+                self.tick(now, snapshot)
+            except Exception as exc:
+                logger.error("YNAB glance update failed (%s)", type(exc).__name__)
+                self._release()
+            self._stop_event.wait(self.poll_seconds)
+
+    def tick(self, now: datetime, snapshot: Optional[YnabSnapshot]):
+        if not self.enabled or not self._is_due(now):
+            self._release()
+            return
+        if snapshot is None:
+            self._release()
+            return
+
+        slot = self._slot_at(now)
+        view = self._view_for_slot(slot)
+        remaining = self.duration - self._cycle_position(now)
+        selected = self.arbiter.claim(
+            self.OWNER,
+            self.priority,
+            min(self.claim_ttl, max(1, remaining)),
+            exclusive=False,
+        )
+        if not selected:
+            self._was_selected = False
+            return
+
+        render_key = (slot, view, snapshot.generated_at, snapshot.stale)
+        still_displayed = self.is_current() if self.is_current else self._was_selected
+        if render_key == self._render_key and self._was_selected and still_displayed:
+            return
+
+        with self.display_lock:
+            if not self.arbiter.can_render(self.OWNER):
+                self._was_selected = False
+                return
+            draw_ynab_view(
+                self.epd,
+                snapshot,
+                view,
+                now=now,
+                set_base_image=not self._was_selected or not still_displayed,
+            )
+
+        if not self._active_view_committed:
+            self._next_view_index = (self._next_view_index + 1) % len(self.views)
+            self._active_view_committed = True
+        self._render_key = render_key
+        self._was_selected = True
+        if self.on_render:
+            self.on_render(self.OWNER)
+
+    def _is_due(self, now: datetime) -> bool:
+        if not self.enabled or not self.interval or not self.duration:
+            return False
+        if self.base_mode_at:
+            mode = self.base_mode_at(now)
+            if isinstance(mode, str) and mode.strip().lower() in {
+                "ynab",
+                "ynab-always",
+            }:
+                return False
+        return self._cycle_position(now) < self.duration
+
+    def _absolute_seconds(self, now: datetime) -> int:
+        seconds_since_midnight = now.hour * 3600 + now.minute * 60 + now.second
+        return now.toordinal() * 86400 + seconds_since_midnight
+
+    def _cycle_position(self, now: datetime) -> int:
+        return (self._absolute_seconds(now) - self.offset) % self.interval
+
+    def _slot_at(self, now: datetime) -> int:
+        return (self._absolute_seconds(now) - self.offset) // self.interval
+
+    def _view_for_slot(self, slot: int) -> str:
+        if slot != self._active_slot:
+            self._active_slot = slot
+            self._active_view = self.views[self._next_view_index]
+            self._active_view_committed = False
+        return self._active_view
+
+    def _release(self, *, restore=True):
+        was_active = self.arbiter.release(self.OWNER)
+        self._was_selected = False
+        self._render_key = None
+        if restore and was_active and self.on_release:
+            self.on_release()


### PR DESCRIPTION
## Summary

- add a low-priority recurring YNAB glance plugin that participates in screen arbitration
- offset YNAB glances from calendar agenda glances and restore the scheduled display after release
- serialize and throttle YNAB snapshot refreshes so concurrent display paths share one request
- document the glance settings and retain fixed YNAB schedule modes

## Why

YNAB views previously needed a fixed schedule window. This makes them glanceable within the normal information rotation while allowing higher-priority calendar, RSS, flight, ISS, breaking-news, and override content to interrupt them.

## Validation

- `DYLD_FALLBACK_LIBRARY_PATH=/opt/homebrew/lib uv run --with pytest --with pillow --with python-dotenv --with requests --with responses --with flask --with requests-cache --with skyfield --with humanize --with pydantic --with ical --with cairosvg --with niquests --with defusedxml --with cryptography --with qrcode pytest` (304 passed)
- `python3 -m py_compile ynab_plugin.py ynab_budget.py basic.py`
- `git diff --check`
- pre-PR runtime deployment on the Raspberry Pi: plugin import succeeded in the service virtualenv and `display.service` restarted active/running

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added optional recurring YNAB budget glances to the display.
  - Glances rotate through configured views, respect display priorities, and yield to higher-priority content.
  - Added configurable enablement, timing, duration, offset, polling, and priority settings.
  - Supports stale snapshots when current budget data is unavailable.

- **Bug Fixes**
  - Improved reliability when multiple budget updates occur simultaneously.
  - Prevented repeated refresh attempts during offline failures.

- **Documentation**
  - Updated setup guidance and display scheduling documentation for YNAB glances.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->