### PR TITLE
Hide absent Codex session limit

### DIFF
--- a/docs/token-usage-display.md
+++ b/docs/token-usage-display.md
@@ -107,5 +107,9 @@ tokens, session names, and project paths are not exposed.
 can be applied from the Codex usage page. Older sources may omit it; the display
 then hides the corner badge.
 
+`limits.primary` is optional. When CodexBar omits the session window because no
+session limit applies, the display also omits the five-hour bar and gives the
+weekly limit the full limits view.
+
 The cost shown from local Codex logs is an estimated API-price equivalent. It
 is not an invoice or the amount charged for a ChatGPT subscription.

--- a/tests/test_token_display.py
+++ b/tests/test_token_display.py
@@ -78,3 +78,20 @@ def test_month_view_uses_snapshot_date_for_today_total():
     snapshot = TokenUsageSnapshot.from_dict(SAMPLE)
 
     assert _today_cost(snapshot) == 83.5
+
+
+def test_limits_view_omits_absent_session_limit(monkeypatch):
+    payload = {**SAMPLE, "limits": {**SAMPLE["limits"]}}
+    payload["limits"].pop("primary")
+    snapshot = TokenUsageSnapshot.from_dict(payload)
+    calls = []
+
+    monkeypatch.setattr(
+        "token_display._limit_bar",
+        lambda draw, black, white, y, title, window, fonts: calls.append((y, title)),
+    )
+    monkeypatch.setattr("token_display._finish", lambda *args: None)
+
+    draw_usage_limits(MockDisplay(), snapshot)
+
+    assert calls == [(53, "WEEK")]

--- a/tests/test_token_usage.py
+++ b/tests/test_token_usage.py
@@ -86,6 +86,16 @@ def test_snapshot_reports_remaining_capacity():
     assert snapshot.month_cost_usd == 123.5
 
 
+def test_snapshot_preserves_an_absent_primary_limit():
+    payload = deepcopy(SAMPLE)
+    del payload["limits"]["primary"]
+
+    snapshot = TokenUsageSnapshot.from_dict(payload)
+
+    assert snapshot.primary.available is False
+    assert snapshot.secondary.available is True
+
+
 def test_snapshot_tolerates_invalid_reset_count():
     payload = {
         **SAMPLE,

--- a/tests/test_token_usage_server.py
+++ b/tests/test_token_usage_server.py
@@ -30,7 +30,8 @@ def test_bridge_normalizes_and_removes_identity_fields(monkeypatch, tmp_path):
     ]
     activity_file = tmp_path / "session.jsonl"
     activity_file.write_text("{}\n", encoding="utf-8")
-    builder = SnapshotBuilder("codexbar", 300, RecentJsonActivity([tmp_path], 300))
+    activity = RecentJsonActivity([tmp_path], 300)
+    builder = SnapshotBuilder("codexbar", 300, activity)
 
     def fake_run(*arguments):
         return usage if arguments[0] == "usage" else cost
@@ -45,6 +46,21 @@ def test_bridge_normalizes_and_removes_identity_fields(monkeypatch, tmp_path):
     assert snapshot["active"] is True
     assert "email" not in serialized
     assert "project" not in serialized
+
+
+def test_bridge_omits_primary_limit_when_codexbar_does(monkeypatch, tmp_path):
+    usage = [{"usage": {"secondary": {"usedPercent": 40}}}]
+    cost = [{"currencyCode": "USD", "daily": []}]
+    builder = SnapshotBuilder("codexbar", 300, RecentJsonActivity([tmp_path], 300))
+
+    monkeypatch.setattr(
+        builder,
+        "_run",
+        lambda *arguments: usage if arguments[0] == "usage" else cost,
+    )
+    monkeypatch.setattr("tools.token_usage_server.datetime", _JulyDatetime)
+
+    assert "primary" not in builder.build()["limits"]
 
 
 def test_recent_json_activity_uses_modification_window(tmp_path):

--- a/token_display.py
+++ b/token_display.py
@@ -222,8 +222,14 @@ def draw_usage_limits(epd, snapshot: TokenUsageSnapshot, set_base_image: bool = 
         fonts,
         resets_available=snapshot.resets_available,
     )
-    _limit_bar(draw, black, white, 31, "5 HOUR", snapshot.primary, fonts)
-    _limit_bar(draw, black, white, 76, "WEEK", snapshot.secondary, fonts)
+    if snapshot.primary.available:
+        _limit_bar(draw, black, white, 31, "5 HOUR", snapshot.primary, fonts)
+        _limit_bar(draw, black, white, 76, "WEEK", snapshot.secondary, fonts)
+    else:
+        # CodexBar omits rate windows that the service does not return. Keep
+        # the same semantics here and let the weekly view breathe while the
+        # temporary session-limit removal is active.
+        _limit_bar(draw, black, white, 53, "WEEK", snapshot.secondary, fonts)
     _finish(epd, image, set_base_image)
 
 

--- a/token_usage.py
+++ b/token_usage.py
@@ -131,6 +131,7 @@ class DisplaySchedule:
 class RateWindow:
     used_percent: float
     resets_at: Optional[str] = None
+    available: bool = True
 
     @property
     def remaining_percent(self) -> float:
@@ -180,10 +181,14 @@ class TokenUsageSnapshot:
         return cls(
             generated_at=str(payload.get("generated_at") or ""),
             primary=RateWindow(
-                float(primary.get("used_percent", 0)), primary.get("resets_at")
+                float(primary.get("used_percent", 0)),
+                primary.get("resets_at"),
+                available=bool(primary),
             ),
             secondary=RateWindow(
-                float(secondary.get("used_percent", 0)), secondary.get("resets_at")
+                float(secondary.get("used_percent", 0)),
+                secondary.get("resets_at"),
+                available=bool(secondary),
             ),
             daily=daily,
             month_cost_usd=float(

--- a/tools/token_usage_server.py
+++ b/tools/token_usage_server.py
@@ -104,21 +104,23 @@ class SnapshotBuilder:
                 resets_available = max(0, int(reset_credits.get("availableCount", 0)))
             except (TypeError, ValueError):
                 resets_available = 0
+            limits = {
+                "resets_available": resets_available,
+                "secondary": {
+                    "used_percent": float(secondary.get("usedPercent", 0)),
+                    "resets_at": secondary.get("resetsAt"),
+                },
+            }
+            if primary:
+                limits["primary"] = {
+                    "used_percent": float(primary.get("usedPercent", 0)),
+                    "resets_at": primary.get("resetsAt"),
+                }
             self._cached = {
                 "schema_version": 1,
                 "generated_at": datetime.now().astimezone().isoformat(),
                 "currency": cost.get("currencyCode", "USD"),
-                "limits": {
-                    "resets_available": resets_available,
-                    "primary": {
-                        "used_percent": float(primary.get("usedPercent", 0)),
-                        "resets_at": primary.get("resetsAt"),
-                    },
-                    "secondary": {
-                        "used_percent": float(secondary.get("usedPercent", 0)),
-                        "resets_at": secondary.get("resetsAt"),
-                    },
-                },
+                "limits": limits,
                 "month_to_date": {
                     "cost_usd": round(sum(item["cost_usd"] for item in daily), 6),
                     "total_tokens": sum(item["total_tokens"] for item in daily),


### PR DESCRIPTION
## What changed

- preserve an absent primary/session window from CodexBar through the normalized snapshot
- omit the five-hour capacity block when that window is unavailable
- center the weekly capacity block to use the freed display space
- document the optional primary limit and cover bridge, model, and render behavior

## Why

Codex has temporarily removed the five-hour usage restriction for Plus, Business, and Pro. CodexBar represents that state by omitting the session window; the display previously normalized the omission to a misleading 100% five-hour limit.

Announcement: https://x.com/thsottiaux/status/2076365965915467978

## Validation

- `.venv/bin/pytest -q tests/test_token_usage.py tests/test_token_display.py tests/test_token_usage_server.py` (31 passed)
- `git diff --check`
- visually inspected the MockDisplay render for the weekly-only layout