### PR TITLE
Add memory-bounded Google Calendar API ingestion

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -104,11 +104,18 @@ display_override_api_token=
 display_override_duration_seconds=300
 display_override_priority=30
 
-# Optional read-only calendar display. Google Calendar exposes the URL under
-# Settings -> Integrate calendar -> Secret address in iCal format. Treat the
-# URL like a password and store it only in the ignored .env file.
+# Optional read-only calendar display. The bounded Google API source is
+# recommended on the Pi. Keep credentials and calendar identifiers only in the
+# ignored .env and in files outside this repository.
 calendar_enabled=false
-calendar_source=ics
+calendar_source=google_api
+# Preferred bounded source. Keep this key file outside the repository and share
+# each calendar read-only with the service account's client_email.
+calendar_google_credentials_file=
+calendar_google_calendar_ids=
+calendar_google_delegated_user=
+calendar_google_max_events=100
+# Legacy unbounded ICS source (not recommended on memory-limited devices):
 calendar_ics_urls=
 calendar_timezone=Europe/Brussels
 calendar_refresh_interval=300

--- a/calendar_service.py
+++ b/calendar_service.py
@@ -381,14 +381,19 @@ class GoogleCalendarApiSource:
     ):
         events = []
         for item in items:
+            if not isinstance(item, dict):
+                continue
             if item.get("status", "confirmed").upper() == "CANCELLED":
                 continue
-            start, all_day = GoogleCalendarApiSource._api_datetime(
-                item.get("start", {}), timezone
-            )
-            end, _ = GoogleCalendarApiSource._api_datetime(
-                item.get("end") or item.get("start", {}), timezone
-            )
+            try:
+                start, all_day = GoogleCalendarApiSource._api_datetime(
+                    item.get("start") or {}, timezone
+                )
+                end, _ = GoogleCalendarApiSource._api_datetime(
+                    item.get("end") or item.get("start") or {}, timezone
+                )
+            except (TypeError, ValueError):
+                continue
             if (all_day and end <= range_start) or (
                 not all_day and start < range_start
             ):
@@ -415,6 +420,8 @@ class GoogleCalendarApiSource:
 
     @staticmethod
     def _api_datetime(value, timezone):
+        if not isinstance(value, dict):
+            raise ValueError("Google Calendar event has no start/end date")
         if value.get("dateTime"):
             parsed = datetime.fromisoformat(value["dateTime"].replace("Z", "+00:00"))
             if parsed.tzinfo is None:
@@ -493,12 +500,11 @@ class CalendarClient:
                         os.getenv("calendar_google_calendar_id", ""),
                     )
                 )
-                if self.enabled and (not calendar_ids or not credentials_value):
-                    logger.error(
-                        "Calendar display enabled but Google API configuration is incomplete"
-                    )
-                    return []
-                if not calendar_ids:
+                if not calendar_ids or not credentials_value:
+                    if self.enabled:
+                        logger.error(
+                            "Calendar display enabled but Google API configuration is incomplete"
+                        )
                     return []
                 credentials_file = Path(credentials_value).expanduser()
                 max_events = int(os.getenv("calendar_google_max_events", "100"))

--- a/calendar_service.py
+++ b/calendar_service.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import hashlib
+import json
 import logging
 import os
 import threading
@@ -11,12 +12,18 @@ from dataclasses import dataclass, replace
 from datetime import date, datetime, time as datetime_time, timedelta
 from pathlib import Path
 from typing import Iterable, List, Optional
+from urllib.parse import quote
 from zoneinfo import ZoneInfo
 
 import requests
 from ical.calendar_stream import IcsCalendarStream
 
 logger = logging.getLogger(__name__)
+logging.getLogger("ical").setLevel(logging.WARNING)
+
+GOOGLE_CALENDAR_READONLY_SCOPE = (
+    "https://www.googleapis.com/auth/calendar.events.readonly"
+)
 
 
 def _enabled(name: str, default: str = "false") -> bool:
@@ -93,7 +100,11 @@ def parse_ics_events(
 
 
 class IcsCalendarSource:
-    """Fetch one HTTP or file ICS source with a private last-good cache."""
+    """Fetch one HTTP or file ICS source with a private last-good cache.
+
+    HTTP ICS is a legacy compatibility path: the response and calendar model are
+    inherently unbounded. Prefer GoogleCalendarApiSource on memory-limited hosts.
+    """
 
     def __init__(
         self,
@@ -236,10 +247,216 @@ class IcsCalendarSource:
             return None
 
 
+class GoogleCalendarApiSource:
+    """Read a strictly bounded window from Google Calendar's Events API."""
+
+    def __init__(
+        self,
+        calendar_id: str,
+        *,
+        credentials_file: Path,
+        cache_dir: Path,
+        timeout: float,
+        max_stale_seconds: int,
+        max_events: int = 100,
+        delegated_user: str = "",
+        session=None,
+        credentials=None,
+    ):
+        if not calendar_id:
+            raise ValueError("calendar_google_calendar_id is required")
+        if max_events < 1:
+            raise ValueError("calendar_google_max_events must be positive")
+        self.calendar_id = calendar_id
+        self.timeout = timeout
+        self.max_stale_seconds = max_stale_seconds
+        self.max_events = max_events
+        self.session = session or requests.Session()
+        self.label = (
+            "google-api-" + hashlib.sha256(calendar_id.encode("utf-8")).hexdigest()[:16]
+        )
+        self.cache_file = cache_dir / f"calendar-{self.label}.json"
+        if credentials is None:
+            from google.oauth2 import service_account
+
+            credentials = service_account.Credentials.from_service_account_file(
+                str(credentials_file), scopes=[GOOGLE_CALENDAR_READONLY_SCOPE]
+            )
+            if delegated_user:
+                credentials = credentials.with_subject(delegated_user)
+        self.credentials = credentials
+
+    def events_between(
+        self,
+        range_start: datetime,
+        range_end: datetime,
+        *,
+        timezone: ZoneInfo,
+        include_all_day: bool,
+        show_details: bool,
+    ) -> List[CalendarEvent]:
+        try:
+            raw_events = self._fetch(range_start, range_end, timezone)
+            events = self._normalize(
+                raw_events,
+                range_start,
+                range_end,
+                timezone,
+                include_all_day,
+                show_details,
+                stale=False,
+            )
+            self._write_cache(raw_events)
+            return events
+        except Exception as exc:
+            logger.warning(
+                "Calendar source %s unavailable (%s)", self.label, type(exc).__name__
+            )
+            cached = self._read_cache()
+            if cached is None:
+                return []
+            return self._normalize(
+                cached,
+                range_start,
+                range_end,
+                timezone,
+                include_all_day,
+                show_details,
+                stale=True,
+            )
+
+    def _fetch(self, range_start, range_end, timezone):
+        if not getattr(self.credentials, "valid", False):
+            from google.auth.transport.requests import Request as GoogleAuthRequest
+
+            self.credentials.refresh(GoogleAuthRequest(session=self.session))
+        url = (
+            "https://www.googleapis.com/calendar/v3/calendars/"
+            f"{quote(self.calendar_id, safe='')}/events"
+        )
+        params = {
+            "timeMin": range_start.isoformat(),
+            "timeMax": range_end.isoformat(),
+            "singleEvents": "true",
+            "orderBy": "startTime",
+            "timeZone": str(timezone),
+            "maxResults": min(self.max_events, 2500),
+            "fields": (
+                "items(id,iCalUID,status,summary,location,start,end),nextPageToken"
+            ),
+        }
+        headers = {
+            "Authorization": f"Bearer {self.credentials.token}",
+            "Accept": "application/json",
+            "User-Agent": "rpi-waiting-time-display/1",
+        }
+        items = []
+        while len(items) < self.max_events:
+            response = self.session.get(
+                url, params=params, headers=headers, timeout=self.timeout
+            )
+            response.raise_for_status()
+            page = response.json()
+            page_items = page.get("items", [])
+            if not isinstance(page_items, list):
+                raise ValueError("Google Calendar returned invalid items")
+            items.extend(page_items[: self.max_events - len(items)])
+            page_token = page.get("nextPageToken")
+            if not page_token or len(items) >= self.max_events:
+                break
+            params["pageToken"] = page_token
+            params["maxResults"] = min(self.max_events - len(items), 2500)
+        return items
+
+    @staticmethod
+    def _normalize(
+        items,
+        range_start,
+        range_end,
+        timezone,
+        include_all_day,
+        show_details,
+        *,
+        stale,
+    ):
+        events = []
+        for item in items:
+            if item.get("status", "confirmed").upper() == "CANCELLED":
+                continue
+            start, all_day = GoogleCalendarApiSource._api_datetime(
+                item.get("start", {}), timezone
+            )
+            end, _ = GoogleCalendarApiSource._api_datetime(
+                item.get("end") or item.get("start", {}), timezone
+            )
+            if (all_day and end <= range_start) or (
+                not all_day and start < range_start
+            ):
+                continue
+            if start >= range_end or (all_day and not include_all_day):
+                continue
+            identity = item.get("iCalUID") or item.get("id") or "event"
+            events.append(
+                CalendarEvent(
+                    uid=f"{identity}:{start.isoformat()}",
+                    summary=(
+                        str(item.get("summary") or "Untitled event")
+                        if show_details
+                        else "Busy"
+                    ),
+                    start=start,
+                    end=end,
+                    location=str(item.get("location") or "") if show_details else "",
+                    all_day=all_day,
+                    stale=stale,
+                )
+            )
+        return sorted(events, key=lambda event: (event.start, event.end, event.summary))
+
+    @staticmethod
+    def _api_datetime(value, timezone):
+        if value.get("dateTime"):
+            parsed = datetime.fromisoformat(value["dateTime"].replace("Z", "+00:00"))
+            if parsed.tzinfo is None:
+                parsed = parsed.replace(tzinfo=timezone)
+            return parsed.astimezone(timezone), False
+        if value.get("date"):
+            return (
+                datetime.combine(
+                    date.fromisoformat(value["date"]), datetime_time.min, timezone
+                ),
+                True,
+            )
+        raise ValueError("Google Calendar event has no start/end date")
+
+    def _write_cache(self, items):
+        try:
+            self.cache_file.parent.mkdir(parents=True, exist_ok=True)
+            temporary = self.cache_file.with_suffix(".tmp")
+            temporary.write_text(json.dumps(items, separators=(",", ":")), "utf-8")
+            temporary.chmod(0o600)
+            temporary.replace(self.cache_file)
+        except OSError as exc:
+            logger.warning(
+                "Could not persist calendar cache %s (%s)",
+                self.label,
+                type(exc).__name__,
+            )
+
+    def _read_cache(self):
+        try:
+            if time.time() - self.cache_file.stat().st_mtime > self.max_stale_seconds:
+                return None
+            data = json.loads(self.cache_file.read_text("utf-8"))
+            return data if isinstance(data, list) else None
+        except (OSError, ValueError):
+            return None
+
+
 class CalendarClient:
     """Combine configured sources and cache a normalized upcoming event list."""
 
-    def __init__(self, sources: Optional[Iterable[IcsCalendarSource]] = None):
+    def __init__(self, sources: Optional[Iterable[object]] = None):
         self.enabled = _enabled("calendar_enabled")
         timezone_name = os.getenv("calendar_timezone", "Europe/Brussels").strip()
         try:
@@ -260,21 +477,59 @@ class CalendarClient:
         self._last_fetch_monotonic = 0.0
         self._lock = threading.Lock()
 
-    def _configured_sources(self) -> List[IcsCalendarSource]:
+    def _configured_sources(self) -> List[object]:
         source_type = os.getenv("calendar_source", "ics").strip().lower()
-        if source_type == "file":
-            value = os.getenv("calendar_ics_files", os.getenv("calendar_ics_file", ""))
-        else:
-            value = os.getenv("calendar_ics_urls", os.getenv("calendar_ics_url", ""))
-        locators = _split_sources(value)
-        if self.enabled and not locators:
-            logger.error(
-                "Calendar display enabled but no %s sources configured", source_type
-            )
         cache_dir = Path(os.getenv("calendar_cache_dir", "cache")).expanduser()
         try:
             timeout = float(os.getenv("calendar_timeout", "10"))
             max_stale = int(os.getenv("calendar_max_stale_seconds", "21600"))
+            if source_type == "google_api":
+                credentials_value = os.getenv(
+                    "calendar_google_credentials_file", ""
+                ).strip()
+                calendar_ids = _split_sources(
+                    os.getenv(
+                        "calendar_google_calendar_ids",
+                        os.getenv("calendar_google_calendar_id", ""),
+                    )
+                )
+                if self.enabled and (not calendar_ids or not credentials_value):
+                    logger.error(
+                        "Calendar display enabled but Google API configuration is incomplete"
+                    )
+                    return []
+                if not calendar_ids:
+                    return []
+                credentials_file = Path(credentials_value).expanduser()
+                max_events = int(os.getenv("calendar_google_max_events", "100"))
+                delegated_user = os.getenv("calendar_google_delegated_user", "").strip()
+                return [
+                    GoogleCalendarApiSource(
+                        calendar_id,
+                        credentials_file=credentials_file,
+                        cache_dir=cache_dir,
+                        timeout=timeout,
+                        max_stale_seconds=max_stale,
+                        max_events=max_events,
+                        delegated_user=delegated_user,
+                    )
+                    for calendar_id in calendar_ids
+                ]
+            if source_type == "file":
+                value = os.getenv(
+                    "calendar_ics_files", os.getenv("calendar_ics_file", "")
+                )
+            elif source_type == "ics":
+                value = os.getenv(
+                    "calendar_ics_urls", os.getenv("calendar_ics_url", "")
+                )
+            else:
+                raise ValueError(f"unsupported calendar source: {source_type}")
+            locators = _split_sources(value)
+            if self.enabled and not locators:
+                logger.error(
+                    "Calendar display enabled but no %s sources configured", source_type
+                )
             return [
                 IcsCalendarSource(
                     locator,
@@ -285,7 +540,7 @@ class CalendarClient:
                 )
                 for locator in locators
             ]
-        except ValueError as exc:
+        except (ImportError, OSError, ValueError) as exc:
             logger.error("Invalid calendar configuration: %s", exc)
             return []
 

--- a/docs/calendar-display.md
+++ b/docs/calendar-display.md
@@ -44,7 +44,7 @@ proportional to the next few days, not to the age of the calendar.
 ```dotenv
 calendar_enabled=true
 calendar_source=google_api
-calendar_google_credentials_file=/home/bence/.config/display/calendar-reader.json
+calendar_google_credentials_file=/path/to/calendar-reader.json
 calendar_google_calendar_ids=REDACTED_CALENDAR_ID
 calendar_google_max_events=100
 calendar_timezone=Europe/Brussels

--- a/docs/calendar-display.md
+++ b/docs/calendar-display.md
@@ -25,39 +25,64 @@ preferred default agenda uses the same low priority, so higher-priority plugin
 claims remain able to interrupt it. The normal lead-window event card and its
 exclusive final-ten-minute behavior are unchanged.
 
-## Google Calendar setup
+## Google Calendar setup (recommended)
 
-Google Calendar does not require an OAuth client for this read-only use case.
-On a computer, open the calendar's settings, choose **Integrate calendar**, and
-copy its **Secret address in iCal format**. Google documents the steps in
-[Sync your calendar with computer programs](https://support.google.com/calendar/answer/37648).
+Use the Google Calendar Events API on a Raspberry Pi. It applies `timeMin` and
+`timeMax` at the server, asks Google to expand recurring events and exceptions
+with `singleEvents=true`, and caps each calendar at
+`calendar_google_max_events`. The response and last-good cache therefore stay
+proportional to the next few days, not to the age of the calendar.
 
-Store the address only in the untracked `.env` file:
+1. Enable the Google Calendar API in a Google Cloud project and create a
+   service account key.
+2. Store the downloaded JSON key outside this repository with owner-only file
+   permissions.
+3. Share each calendar read-only with the service account's `client_email`.
+4. Copy each calendar ID from **Settings > Integrate calendar** into the
+   untracked `.env`. Calendar IDs and key paths are never logged.
 
 ```dotenv
 calendar_enabled=true
-calendar_source=ics
-calendar_ics_urls=https://calendar.google.com/calendar/ical/REDACTED/basic.ics
+calendar_source=google_api
+calendar_google_credentials_file=/home/bence/.config/display/calendar-reader.json
+calendar_google_calendar_ids=REDACTED_CALENDAR_ID
+calendar_google_max_events=100
 calendar_timezone=Europe/Brussels
+calendar_lookahead_days=3
 ```
 
-Use a comma-separated `calendar_ics_urls` value for multiple calendars. The
-secret URL is effectively a read-only bearer credential. Never commit it or
-paste it into logs. Reset the secret address in Google Calendar if it is
-exposed. A Workspace administrator may disable secret addresses; in that case
-an authenticated Calendar API or an external bridge such as
-[`gog`](https://github.com/steipete/gogcli) is the fallback, but it requires a
-Google Cloud OAuth client and persistent token/keyring setup.
+Use comma-separated `calendar_google_calendar_ids` for multiple calendars. A
+Workspace administrator may instead grant domain-wide delegation; set
+`calendar_google_delegated_user` only when that has been intentionally
+configured. The implementation requests only the
+`calendar.events.readonly` OAuth scope.
+
+### Migrating from a Google secret ICS URL
+
+Replace `calendar_source=ics` and `calendar_ics_urls=...` with the API settings
+above. Do not enable the calendar again on a memory-limited Pi until the service
+account can retrieve the bounded API window. The secret ICS address can then be
+removed from `.env` and revoked if it may have been exposed.
+
+HTTP ICS remains available for small non-Google calendars, and `file` remains
+available for externally synchronized files. Both are legacy compatibility
+paths: an ICS feed has no standard `timeMin`/`timeMax` request, and recurrence
+masters, exceptions, and `VTIMEZONE` definitions may be separated anywhere in
+the file. Pre-filtering VEVENT blocks before a standards-compliant parse can
+therefore silently lose or mis-time occurrences. The application must parse an
+entire ICS source to preserve those semantics, so do not point the ICS mode at
+a large historical Google feed on a constrained device.
 
 For development or an externally synchronized feed, use `calendar_source=file`
 with `calendar_ics_file` or comma-separated `calendar_ics_files` paths.
 
 ## Refresh and failure behavior
 
-HTTP feeds refresh every five minutes by default and use ETag/Last-Modified
-conditional requests when available. Successful responses are cached under
-`cache/` with owner-only permissions. If a source is temporarily unavailable,
-the plugin may show its last-good events as stale for
+Sources refresh every five minutes by default. Google API calls are bounded by
+the requested time window and event cap; HTTP ICS feeds use ETag/Last-Modified
+conditional requests when available. Successful bounded API results or ICS
+responses are cached under `cache/` with owner-only permissions. If a source is
+temporarily unavailable, the plugin may show its last-good events as stale for
 `calendar_max_stale_seconds`, but stale events never receive the exclusive
 pre-event lease.
 

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -29,6 +29,7 @@ pytest>=8.0.0
 pytest-mock>=3.15.1
 pytest-cov>=4.1.0
 ical>=11.1.0,<12
+google-auth>=2.40.0,<3
 responses>=0.24.1
 freezegun>=1.4.0
 black>=24.1.1

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -29,7 +29,7 @@ pytest>=8.0.0
 pytest-mock>=3.15.1
 pytest-cov>=4.1.0
 ical>=11.1.0,<12
-google-auth>=2.40.0,<3
+google-auth==2.55.2
 responses>=0.24.1
 freezegun>=1.4.0
 black>=24.1.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -64,7 +64,7 @@ cryptography>=46.0.5
 filelock>=3.20.3
 h11>=0.16.0
 pydantic==2.13.3
-google-auth>=2.40.0,<3
+google-auth==2.55.2
 ical==11.1.0
 cairosvg==2.9.0
 niquests==3.17.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -64,6 +64,7 @@ cryptography>=46.0.5
 filelock>=3.20.3
 h11>=0.16.0
 pydantic==2.13.3
+google-auth>=2.40.0,<3
 ical==11.1.0
 cairosvg==2.9.0
 niquests==3.17.0

--- a/tests/test_calendar_service.py
+++ b/tests/test_calendar_service.py
@@ -5,7 +5,12 @@ from zoneinfo import ZoneInfo
 
 import requests
 
-from calendar_service import CalendarClient, IcsCalendarSource, parse_ics_events
+from calendar_service import (
+    CalendarClient,
+    GoogleCalendarApiSource,
+    IcsCalendarSource,
+    parse_ics_events,
+)
 
 TIMEZONE = ZoneInfo("Europe/Brussels")
 NOW = datetime(2026, 7, 11, 8, 0, tzinfo=TIMEZONE)
@@ -37,14 +42,20 @@ END:VCALENDAR
 
 
 class FakeResponse:
-    def __init__(self, status_code, text="", headers=None):
+    def __init__(self, status_code, text="", headers=None, json_data=None):
         self.status_code = status_code
         self.text = text
         self.headers = headers or {}
+        self.json_data = json_data
 
     def raise_for_status(self):
         if self.status_code >= 400:
             raise requests.HTTPError(f"HTTP {self.status_code}")
+
+    def json(self):
+        if self.json_data is None:
+            raise ValueError("no JSON response")
+        return self.json_data
 
 
 class FakeSession:
@@ -58,6 +69,11 @@ class FakeSession:
         if isinstance(response, Exception):
             raise response
         return response
+
+
+class FakeCredentials:
+    valid = True
+    token = "test-token"
 
 
 def test_parser_expands_recurring_events_and_skips_cancelled():
@@ -223,6 +239,121 @@ def test_file_source_reads_local_ics(tmp_path):
 
     assert len(events) == 2
     assert all(not event.stale for event in events)
+
+
+def _api_event(index, *, day=12):
+    return {
+        "id": f"instance-{index}",
+        "iCalUID": "weekly@example.test",
+        "status": "confirmed",
+        "summary": f"Meeting {index}",
+        "start": {"dateTime": f"2026-07-{day:02d}T10:00:00+02:00"},
+        "end": {"dateTime": f"2026-07-{day:02d}T10:30:00+02:00"},
+    }
+
+
+def test_google_api_requests_bounded_server_expanded_window(tmp_path):
+    session = FakeSession([FakeResponse(200, json_data={"items": [_api_event(1)]})])
+    source = GoogleCalendarApiSource(
+        "private-calendar@example.test",
+        credentials_file=tmp_path / "unused.json",
+        cache_dir=tmp_path,
+        timeout=5,
+        max_stale_seconds=3600,
+        max_events=20,
+        session=session,
+        credentials=FakeCredentials(),
+    )
+
+    events = source.events_between(
+        NOW,
+        NOW + timedelta(days=3),
+        timezone=TIMEZONE,
+        include_all_day=False,
+        show_details=True,
+    )
+
+    assert len(events) == 1
+    url, request = session.calls[0]
+    assert "@" not in url
+    assert "%40" in url
+    assert request["params"]["timeMin"] == NOW.isoformat()
+    assert request["params"]["timeMax"] == (NOW + timedelta(days=3)).isoformat()
+    assert request["params"]["singleEvents"] == "true"
+    assert request["params"]["orderBy"] == "startTime"
+    assert request["params"]["maxResults"] == 20
+
+
+def test_google_api_caps_pagination_and_private_cache_size(tmp_path):
+    session = FakeSession(
+        [
+            FakeResponse(
+                200,
+                json_data={
+                    "items": [_api_event(index) for index in range(80)],
+                    "nextPageToken": "more",
+                },
+            )
+        ]
+    )
+    source = GoogleCalendarApiSource(
+        "calendar-id",
+        credentials_file=tmp_path / "unused.json",
+        cache_dir=tmp_path,
+        timeout=5,
+        max_stale_seconds=3600,
+        max_events=25,
+        session=session,
+        credentials=FakeCredentials(),
+    )
+
+    events = source.events_between(
+        NOW,
+        NOW + timedelta(days=3),
+        timezone=TIMEZONE,
+        include_all_day=False,
+        show_details=True,
+    )
+
+    assert len(events) == 25
+    assert len(session.calls) == 1
+    assert source.cache_file.stat().st_size < 20_000
+    assert stat.S_IMODE(source.cache_file.stat().st_mode) == 0o600
+
+
+def test_google_api_uses_stale_bounded_cache(tmp_path):
+    source = GoogleCalendarApiSource(
+        "calendar-id",
+        credentials_file=tmp_path / "unused.json",
+        cache_dir=tmp_path,
+        timeout=5,
+        max_stale_seconds=3600,
+        session=FakeSession(
+            [
+                FakeResponse(200, json_data={"items": [_api_event(1)]}),
+                requests.ConnectionError("offline"),
+            ]
+        ),
+        credentials=FakeCredentials(),
+    )
+    source.events_between(
+        NOW,
+        NOW + timedelta(days=3),
+        timezone=TIMEZONE,
+        include_all_day=False,
+        show_details=True,
+    )
+
+    events = source.events_between(
+        NOW,
+        NOW + timedelta(days=3),
+        timezone=TIMEZONE,
+        include_all_day=False,
+        show_details=True,
+    )
+
+    assert len(events) == 1
+    assert events[0].stale is True
 
 
 def test_calendar_client_reads_configured_file_source(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- add a bounded Google Calendar Events API source using server-side `timeMin`/`timeMax` and recurring-instance expansion
- hard-cap responses and owner-only JSON caches, with stale fallback and credential-safe logging
- retain ICS/file sources as documented legacy compatibility paths and suppress noisy third-party `ical` DEBUG logs
- document service-account migration and add API/cap/cache coverage

## Why
A large private Google ICS feed is parsed and materialized in full before the existing timeline window is applied. On a 416 MiB Raspberry Pi, a long calendar history can exhaust RAM and swap. The Events API applies the window authoritatively before data reaches the device and preserves Google recurrence exceptions via `singleEvents=true`.

## Validation
- `pytest -q`: 336 passed
- `pytest -q tests/test_calendar_service.py tests/test_calendar_plugin.py`: 28 passed
- `git diff --check`

Deployment remains held and is owned by the project coordinator; this PR does not enable calendar ingestion on a device.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Google Calendar API integration with bounded event retrieval, pagination limits, and support for multiple calendars.
  * Added secure caching and fallback to previously retrieved events when the service is unavailable.
  * Preserved support for legacy ICS calendar sources.

* **Documentation**
  * Updated setup guidance with recommended Google Calendar configuration and migration steps from ICS URLs.
  * Added configuration options for credentials, calendars, time zones, lookahead periods, and event limits.

* **Bug Fixes**
  * Improved handling of cancelled events and calendar configuration errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->