### PR TITLE
Add resilient ADS-B provider fallback

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -80,6 +80,7 @@ AEROAPI_BASE_URL = https://aeroapi.flightaware.com/aeroapi
 # AeroAPI active hours - time periods when API calls are allowed (default: 0-24 for always active)
 # Examples: 8-18 (8AM-6PM), 22-6 (10PM-6AM), 8-10,14-16,20-22 (multiple periods)
 aeroapi_active_hours = 0-24
+ADSB_API_BASE_URLS = https://api.adsb.lol,https://api.adsb.one
 
 
 # ISS tracking configuration

--- a/flights.py
+++ b/flights.py
@@ -52,8 +52,7 @@ flight_session = CachedSession(
     backend='memory',
     expire_after=3600,  # Cache expires after 1 hour
     urls_expire_after={
-        'https://api.adsb.lol/v2/point': 0,  # Do not cache ADS-B API calls
-        'https://api.adsb.one/v2/point': 0,  # Do not cache ADS-B API calls
+        **{f'{url}/v2/point': 0 for url in ADSB_API_BASE_URLS},
         f'{AEROAPI_BASE_URL}/account/usage': 0,  # Do not cache usage endpoint check
     }
 )

--- a/flights.py
+++ b/flights.py
@@ -33,12 +33,26 @@ if not AEROAPI_BASE_URL.endswith('/aeroapi'):
 # Ensure the base URL doesn't end with a slash to prevent double slashes in requests
 AEROAPI_BASE_URL = AEROAPI_BASE_URL.rstrip('/')
 
+ADSB_API_BASE_URLS = tuple(
+    url.strip().rstrip('/')
+    for url in os.getenv(
+        'ADSB_API_BASE_URLS',
+        'https://api.adsb.lol,https://api.adsb.one',
+    ).split(',')
+    if url.strip()
+)
+ADSB_REQUEST_HEADERS = {
+    'Accept': 'application/json',
+    'User-Agent': 'rpi-waiting-time-display/1.0',
+}
+
 # Create a cached session specifically for flight requests
 flight_session = CachedSession(
     'flight_cache',
     backend='memory',
     expire_after=3600,  # Cache expires after 1 hour
     urls_expire_after={
+        'https://api.adsb.lol/v2/point': 0,  # Do not cache ADS-B API calls
         'https://api.adsb.one/v2/point': 0,  # Do not cache ADS-B API calls
         f'{AEROAPI_BASE_URL}/account/usage': 0,  # Do not cache usage endpoint check
     }
@@ -190,6 +204,32 @@ def is_aeroapi_active():
     return False
 
 
+def fetch_adsb_point(lat, lon, radius):
+    """Fetch nearby aircraft from the first healthy compatible ADS-B API."""
+    for base_url in ADSB_API_BASE_URLS:
+        try:
+            response = flight_session.get(
+                f"{base_url}/v2/point/{lat}/{lon}/{radius}",
+                headers=ADSB_REQUEST_HEADERS,
+                timeout=10,
+            )
+            if response.status_code != 200:
+                logger.warning(
+                    "ADS-B provider %s returned HTTP %s",
+                    base_url,
+                    response.status_code,
+                )
+                continue
+            payload = response.json()
+            if not isinstance(payload, dict) or not isinstance(payload.get('ac'), list):
+                logger.warning("ADS-B provider %s returned an invalid payload", base_url)
+                continue
+            return payload
+        except Exception as exc:
+            logger.warning("ADS-B provider %s failed: %s", base_url, exc)
+    return None
+
+
 @lru_cache(maxsize=1024)
 def haversine(lat1, lon1, lat2, lon2):
     R = 6371000
@@ -230,10 +270,8 @@ def gather_flights_within_radius(lat, lon, radius=radius*2, distance_threshold=r
                 continue
                 
             try:
-                # Use the cached session instead of global requests
-                response = flight_session.get(f"https://api.adsb.one/v2/point/{lat}/{lon}/{radius}")
-                if response.status_code == 200:
-                    data = response.json()
+                data = fetch_adsb_point(lat, lon, radius)
+                if data is not None:
                     logger.debug(f"Found {len(data['ac']) if data and 'ac' in data else 0} flights.")
                     
                     with lock:
@@ -269,7 +307,7 @@ def gather_flights_within_radius(lat, lon, radius=radius*2, distance_threshold=r
                     _backoff.update_backoff_state(True)
                 else:
                     _backoff.update_backoff_state(False)
-                    logger.error(f"Error response from flight API: {response.status_code}")
+                    logger.error("All configured ADS-B providers failed")
 
                 last_check_time = current_time
                 

--- a/tests/test_recent_flights.py
+++ b/tests/test_recent_flights.py
@@ -3,7 +3,7 @@ from threading import Lock, RLock
 from unittest.mock import Mock, patch
 
 from display_adapter import MockDisplay
-from flights import RecentFlightCache, update_display_with_recent_flights
+from flights import RecentFlightCache, fetch_adsb_point, update_display_with_recent_flights
 from screen_arbiter import ScreenArbiter
 
 
@@ -25,6 +25,42 @@ def test_recent_flight_cache_rejects_entries_without_an_identifier():
 
     assert not cache.record({"origin_code": "BRU"})
     assert cache.recent() == []
+
+
+def test_adsb_point_fetch_falls_back_to_next_compatible_provider(monkeypatch):
+    class Response:
+        def __init__(self, status_code, payload=None):
+            self.status_code = status_code
+            self._payload = payload
+
+        def json(self):
+            return self._payload
+
+    calls = []
+    responses = iter([Response(403), Response(200, {"ac": [{"hex": "abc"}]})])
+
+    def get(url, **kwargs):
+        calls.append((url, kwargs))
+        return next(responses)
+
+    monkeypatch.setattr("flights.ADSB_API_BASE_URLS", ("https://one", "https://two"))
+    monkeypatch.setattr("flights.flight_session.get", get)
+
+    assert fetch_adsb_point(50.0, 4.0, 6) == {"ac": [{"hex": "abc"}]}
+    assert [call[0] for call in calls] == [
+        "https://one/v2/point/50.0/4.0/6",
+        "https://two/v2/point/50.0/4.0/6",
+    ]
+    assert all(call[1]["timeout"] == 10 for call in calls)
+
+
+def test_adsb_point_fetch_rejects_invalid_payloads(monkeypatch):
+    response = Mock(status_code=200)
+    response.json.return_value = {"ac": None}
+    monkeypatch.setattr("flights.ADSB_API_BASE_URLS", ("https://one",))
+    monkeypatch.setattr("flights.flight_session.get", lambda *args, **kwargs: response)
+
+    assert fetch_adsb_point(50.0, 4.0, 6) is None
 
 
 def test_recent_flights_renderer_handles_partial_and_missing_route_data(monkeypatch):

--- a/tests/test_recent_flights.py
+++ b/tests/test_recent_flights.py
@@ -3,7 +3,13 @@ from threading import Lock, RLock
 from unittest.mock import Mock, patch
 
 from display_adapter import MockDisplay
-from flights import RecentFlightCache, fetch_adsb_point, update_display_with_recent_flights
+from flights import (
+    ADSB_API_BASE_URLS,
+    RecentFlightCache,
+    fetch_adsb_point,
+    flight_session,
+    update_display_with_recent_flights,
+)
 from screen_arbiter import ScreenArbiter
 
 
@@ -52,6 +58,11 @@ def test_adsb_point_fetch_falls_back_to_next_compatible_provider(monkeypatch):
         "https://two/v2/point/50.0/4.0/6",
     ]
     assert all(call[1]["timeout"] == 10 for call in calls)
+
+
+def test_all_configured_adsb_providers_bypass_the_flight_cache():
+    for base_url in ADSB_API_BASE_URLS:
+        assert flight_session.settings.urls_expire_after[f"{base_url}/v2/point"] == 0
 
 
 def test_adsb_point_fetch_rejects_invalid_payloads(monkeypatch):


### PR DESCRIPTION
## What changed

- use ADSB.lol as the default live-position provider
- retain ADSB.one as a compatible fallback
- add identified, bounded ADS-B requests and validate response shape
- back off only after all configured providers fail
- document the provider list and add failover regression tests

## Root cause

The display's only position source, `api.adsb.one`, began returning a Cloudflare HTTP 403 to the display network. The monitoring loop treated that single-provider failure as a total outage and entered exponential backoff.

## Impact

Nearby-aircraft monitoring can continue when one compatible public ADS-B provider is unavailable, without adding credentials or weakening network protections.

## Validation

- focused flight and override tests: 20 passed
- full pytest suite: passed
- live read-only probe from the display Pi: ADSB.lol returned HTTP 200 with the expected `ac` list schema

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for multiple ADS-B data providers with automatic failover.
  * Added configurable provider endpoints through the application environment settings.
  * Improved resilience when a provider is unavailable or returns invalid data.

* **Bug Fixes**
  * Added clearer error reporting when all configured ADS-B providers fail.

* **Tests**
  * Added coverage for provider fallback and invalid response handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->