### PR TITLE
Throttle external ADS-B position requests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -63,8 +63,10 @@ hotspot_password=YourPassword
 
 # Flight monitoring settings
 flights_enabled=true
-# How often to check for flights (in seconds) - remember to make this lower than the refresh_minimal_time setting in the display settings but higher than 1 seconds to respect the API rate limits
+# How often the display checks its local flight data (in seconds)
 flight_check_interval=5
+# Minimum interval between external ADS-B position requests (in seconds)
+adsb_request_interval=15
 flight_max_radius=3
 flight_altitude_convert_feet=false
 # How often to update the display when tracking a flight (in seconds). Uses fast mode with partial refresh if supported, otherwise uses refresh_minimal_time.

--- a/flights.py
+++ b/flights.py
@@ -68,6 +68,7 @@ lon = os.getenv('Coordinates_LNG')
 
 radius = int(os.getenv('flight_max_radius', 3))
 flight_check_interval = int(os.getenv('flight_check_interval', 10))
+ADSB_REQUEST_INTERVAL = max(1, int(os.getenv('adsb_request_interval', 15)))
 aeroapi_enabled = os.getenv("aeroapi_enabled", "false").lower() == "true"
 aeroapi_key = os.getenv("aeroapi_key")
 aeroapi_enable_paid_usage = os.getenv("aeroapi_enable_paid_usage", "false").lower() == "true"
@@ -229,6 +230,11 @@ def fetch_adsb_point(lat, lon, radius):
     return None
 
 
+def get_adsb_request_interval(display_check_interval):
+    """Keep external position requests slower than local display checks."""
+    return max(display_check_interval, ADSB_REQUEST_INTERVAL)
+
+
 @lru_cache(maxsize=1024)
 def haversine(lat1, lon1, lat2, lon2):
     R = 6371000
@@ -249,6 +255,7 @@ def gather_flights_within_radius(lat, lon, radius=radius*2, distance_threshold=r
     stop_event = Event()  # Create stop_event here
     # Initialize backoff with 1 minute initial and 1 hour max
     _backoff = ExponentialBackoff(initial_backoff=60, max_backoff=3600)
+    request_interval = get_adsb_request_interval(flight_check_interval)
     logger.debug(f"Monitoring flights within {radius}km of {lat}, {lon}, with threshold {distance_threshold} km")
     
     def gather_data():
@@ -258,7 +265,7 @@ def gather_flights_within_radius(lat, lon, radius=radius*2, distance_threshold=r
             current_time = time.time()
             
             # Ensure minimum interval between checks
-            if current_time - last_check_time < flight_check_interval:
+            if current_time - last_check_time < request_interval:
                 time.sleep(1)  # Short sleep to prevent CPU spinning
                 continue
 
@@ -313,10 +320,10 @@ def gather_flights_within_radius(lat, lon, radius=radius*2, distance_threshold=r
             except Exception as e:
                 _backoff.update_backoff_state(False)
                 logger.error(f"Error gathering flight data: {e}")
-                time.sleep(flight_check_interval)  # Sleep on error
+                time.sleep(request_interval)  # Sleep on error
             
             # Sleep for the remaining interval time
-            time_to_sleep = max(0, flight_check_interval - (time.time() - current_time))
+            time_to_sleep = max(0, request_interval - (time.time() - current_time))
             if time_to_sleep > 0:
                 time.sleep(time_to_sleep)
 

--- a/tests/test_recent_flights.py
+++ b/tests/test_recent_flights.py
@@ -8,6 +8,7 @@ from flights import (
     RecentFlightCache,
     fetch_adsb_point,
     flight_session,
+    get_adsb_request_interval,
     update_display_with_recent_flights,
 )
 from screen_arbiter import ScreenArbiter
@@ -63,6 +64,13 @@ def test_adsb_point_fetch_falls_back_to_next_compatible_provider(monkeypatch):
 def test_all_configured_adsb_providers_bypass_the_flight_cache():
     for base_url in ADSB_API_BASE_URLS:
         assert flight_session.settings.urls_expire_after[f"{base_url}/v2/point"] == 0
+
+
+def test_adsb_requests_are_throttled_independently_of_display_checks(monkeypatch):
+    monkeypatch.setattr("flights.ADSB_REQUEST_INTERVAL", 15)
+
+    assert get_adsb_request_interval(5) == 15
+    assert get_adsb_request_interval(30) == 30
 
 
 def test_adsb_point_fetch_rejects_invalid_payloads(monkeypatch):


### PR DESCRIPTION
Issue 2 follow-up discovered during live deployment verification.

- keep local flight/display checks at their existing cadence
- enforce a separate 15-second default minimum between external ADS-B requests
- document the setting and cover it with a regression test

Verification: 342 tests passed.