### PR TITLE
Support grouped Home Assistant entities

### DIFF
--- a/docs/home-assistant-display.md
+++ b/docs/home-assistant-display.md
@@ -14,6 +14,11 @@ Empty screens are skipped. Cards default to 30 seconds before returning to the
 base display for three minutes. Triggers can claim a target screen on an
 inactive-to-active transition with configurable debounce, priority and TTL.
 
+An entity row may use `entity_ids` instead of `entity_id` to group binary
+sensors. The row is active when any available member is active and clear only
+when every available member is clear. List each member separately in `triggers`
+when either member should claim the screen.
+
 Tokens and household entity IDs belong only in ignored deployment config. The
 service does not log URLs, tokens, headers, or authentication payloads.
 Unavailable updates retain the previous useful value with a stale marker.

--- a/home_assistant_display.py
+++ b/home_assistant_display.py
@@ -8,6 +8,7 @@ from PIL import Image, ImageDraw, ImageFont
 from font_utils import get_font_paths
 
 ROTATION = int(os.getenv("screen_rotation", 90))
+ACTIVE_STATES = {"on", "active", "detected", "true"}
 
 
 def _fonts():
@@ -45,13 +46,31 @@ def _value(entity, state):
     return f"{raw}{unit}", stale
 
 
+def resolve_entity_state(entity, states):
+    """Resolve a row, treating grouped binary entities as active when any is active."""
+    candidates = [states.get(entity_id) for entity_id in entity.source_entity_ids]
+    candidates = [state for state in candidates if state is not None]
+    if not candidates:
+        return None
+    available = [state for state in candidates if state.available]
+    usable = available or candidates
+    active = [
+        state for state in usable if str(state.state).strip().lower() in ACTIVE_STATES
+    ]
+    return max(active or usable, key=lambda state: state.received_monotonic)
+
+
 def screen_has_content(screen, states):
     if screen.type in {"lights", "climate"}:
         return any(
-            (states.get(item.entity_id) and states[item.entity_id].available)
-            for item in screen.entities
+            state and state.available
+            for state in (
+                resolve_entity_state(item, states) for item in screen.entities
+            )
         )
-    return any(states.get(item.entity_id) is not None for item in screen.entities)
+    return any(
+        resolve_entity_state(item, states) is not None for item in screen.entities
+    )
 
 
 def draw_home_assistant_screen(
@@ -73,7 +92,7 @@ def draw_home_assistant_screen(
     )
     items = []
     for entity in screen.entities:
-        state = states.get(entity.entity_id)
+        state = resolve_entity_state(entity, states)
         value, stale = _value(entity, state)
         label = entity.label or entity.entity_id.split(".")[-1].replace("_", " ")
         if now_monotonic is not None and state is not None:

--- a/home_assistant_display.py
+++ b/home_assistant_display.py
@@ -55,7 +55,9 @@ def resolve_entity_state(entity, states):
     available = [state for state in candidates if state.available]
     usable = available or candidates
     active = [
-        state for state in usable if str(state.state).strip().lower() in ACTIVE_STATES
+        state
+        for state in usable
+        if state.state and state.state.strip().lower() in ACTIVE_STATES
     ]
     return max(active or usable, key=lambda state: state.received_monotonic)
 

--- a/home_assistant_models.py
+++ b/home_assistant_models.py
@@ -53,8 +53,8 @@ def parse_config(data) -> HomeAssistantConfig:
             raise ValueError(f"unknown Home Assistant screen type: {kind}")
         entities = []
         for entity in item.get("entities", []):
-            raw_source_ids = entity.get("entity_ids", ())
-            if isinstance(raw_source_ids, (str, bytes)):
+            raw_source_ids = entity.get("entity_ids") or ()
+            if not isinstance(raw_source_ids, (list, tuple)):
                 raise ValueError("Home Assistant entity_ids must be a list")
             source_ids = tuple(dict.fromkeys(str(value) for value in raw_source_ids))
             entity_id = str(

--- a/home_assistant_models.py
+++ b/home_assistant_models.py
@@ -9,6 +9,11 @@ class EntityConfig:
     entity_id: str
     label: str = ""
     attribute: str = ""
+    entity_ids: Tuple[str, ...] = ()
+
+    @property
+    def source_entity_ids(self) -> Tuple[str, ...]:
+        return self.entity_ids or (self.entity_id,)
 
 
 @dataclass(frozen=True)
@@ -46,14 +51,28 @@ def parse_config(data) -> HomeAssistantConfig:
         kind = str(item.get("type", "entities")).lower()
         if kind not in known:
             raise ValueError(f"unknown Home Assistant screen type: {kind}")
-        entities = tuple(
-            EntityConfig(
-                str(entity["entity_id"]),
-                str(entity.get("label", "")),
-                str(entity.get("attribute", "")),
+        entities = []
+        for entity in item.get("entities", []):
+            raw_source_ids = entity.get("entity_ids", ())
+            if isinstance(raw_source_ids, (str, bytes)):
+                raise ValueError("Home Assistant entity_ids must be a list")
+            source_ids = tuple(dict.fromkeys(str(value) for value in raw_source_ids))
+            entity_id = str(
+                entity.get("entity_id") or (source_ids[0] if source_ids else "")
             )
-            for entity in item.get("entities", [])
-        )
+            if not entity_id:
+                raise ValueError(
+                    "Home Assistant entities require entity_id or entity_ids"
+                )
+            entities.append(
+                EntityConfig(
+                    entity_id,
+                    str(entity.get("label", "")),
+                    str(entity.get("attribute", "")),
+                    source_ids,
+                )
+            )
+        entities = tuple(entities)
         if not entities:
             raise ValueError("Home Assistant screens require entities")
         screens.append(

--- a/home_assistant_plugin.py
+++ b/home_assistant_plugin.py
@@ -74,7 +74,10 @@ class HomeAssistantPlugin:
             return None
         config = load_home_assistant_config(os.getenv("home_assistant_config", ""))
         ids = {
-            entity.entity_id for screen in config.screens for entity in screen.entities
+            entity_id
+            for screen in config.screens
+            for entity in screen.entities
+            for entity_id in entity.source_entity_ids
         }
         ids.update(trigger.entity_id for trigger in config.triggers)
         service = HomeAssistantService(
@@ -178,8 +181,9 @@ class HomeAssistantPlugin:
         key = (
             owner,
             tuple(
-                (entity.entity_id, states.get(entity.entity_id))
+                (entity_id, states.get(entity_id))
                 for entity in screen.entities
+                for entity_id in entity.source_entity_ids
             ),
         )
         if key == self._last_key:

--- a/tests/test_home_assistant.py
+++ b/tests/test_home_assistant.py
@@ -3,7 +3,7 @@ import threading
 from datetime import datetime, timezone
 
 from display_adapter import MockDisplay
-from home_assistant_display import draw_home_assistant_screen
+from home_assistant_display import draw_home_assistant_screen, resolve_entity_state
 from home_assistant_models import parse_config
 from home_assistant_plugin import HomeAssistantPlugin
 from home_assistant_service import EntityState, HomeAssistantService
@@ -171,6 +171,75 @@ def test_plugin_rotates_and_motion_transition_takes_over(monkeypatch):
     assert plugin.tick(0)
     assert context.arbiter.active_owner() == "ha-event:pair"
     assert renders == ["pair", "pair"]
+
+
+def test_grouped_binary_entity_is_active_when_either_or_both_members_are_active():
+    config = parse_config(
+        {
+            "screens": [
+                {
+                    "id": "motion",
+                    "type": "entities",
+                    "entities": [
+                        {
+                            "entity_ids": [
+                                "binary_sensor.hall_eve",
+                                "binary_sensor.hall_hue",
+                            ],
+                            "label": "Hall",
+                        }
+                    ],
+                }
+            ]
+        }
+    )
+    entity = config.screens[0].entities[0]
+
+    for eve, hue, expected in (
+        ("off", "off", "off"),
+        ("on", "off", "on"),
+        ("off", "on", "on"),
+        ("on", "on", "on"),
+    ):
+        states = {
+            "binary_sensor.hall_eve": state("binary_sensor.hall_eve", eve, 1),
+            "binary_sensor.hall_hue": state("binary_sensor.hall_hue", hue, 2),
+        }
+        assert resolve_entity_state(entity, states).state == expected
+
+
+def test_plugin_subscribes_to_every_group_member(monkeypatch):
+    monkeypatch.setenv("home_assistant_enabled", "true")
+    monkeypatch.setenv("home_assistant_url", "http://ha.test")
+    monkeypatch.setenv("home_assistant_token", "secret")
+    monkeypatch.setenv(
+        "home_assistant_config",
+        json.dumps(
+            {
+                "screens": [
+                    {
+                        "id": "motion",
+                        "entities": [
+                            {
+                                "entity_ids": [
+                                    "binary_sensor.hall_eve",
+                                    "binary_sensor.hall_hue",
+                                ]
+                            }
+                        ],
+                    }
+                ]
+            }
+        ),
+    )
+    context = PluginContext(MockDisplay(), ScreenArbiter(), threading.Lock())
+
+    plugin = HomeAssistantPlugin.from_env(context)
+
+    assert plugin.service.entity_ids == {
+        "binary_sensor.hall_eve",
+        "binary_sensor.hall_hue",
+    }
 
 
 def test_unavailable_state_preserves_last_good_value():

--- a/tests/test_home_assistant.py
+++ b/tests/test_home_assistant.py
@@ -242,6 +242,38 @@ def test_plugin_subscribes_to_every_group_member(monkeypatch):
     }
 
 
+def test_grouped_entity_parser_handles_null_and_rejects_invalid_types():
+    config = parse_config(
+        {
+            "screens": [
+                {
+                    "id": "motion",
+                    "entities": [
+                        {"entity_id": "binary_sensor.hall", "entity_ids": None}
+                    ],
+                }
+            ]
+        }
+    )
+    assert config.screens[0].entities[0].source_entity_ids == ("binary_sensor.hall",)
+
+    try:
+        parse_config(
+            {
+                "screens": [
+                    {
+                        "id": "motion",
+                        "entities": [{"entity_ids": 123}],
+                    }
+                ]
+            }
+        )
+    except ValueError as exc:
+        assert str(exc) == "Home Assistant entity_ids must be a list"
+    else:
+        raise AssertionError("invalid entity_ids should be rejected")
+
+
 def test_unavailable_state_preserves_last_good_value():
     service = HomeAssistantService("http://ha.test", "secret", ["sensor.left"])
     service._store({"entity_id": "sensor.left", "state": "11", "attributes": {}}, False)


### PR DESCRIPTION
Allow one display row to aggregate multiple Home Assistant binary entities. A grouped row is active when any available member is active, and the plugin subscribes to every member so either transition refreshes the screen.

This keeps household IDs out of the public repository while enabling a private Hall row backed by two motion sensors.

Verification: 344 tests passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for grouping multiple Home Assistant binary sensors in a single display row.
  * Grouped rows become active when any available sensor is active and clear only when all available sensors are clear.
  * Screens now subscribe to and reflect updates from every configured sensor.
* **Documentation**
  * Documented grouped sensor configuration and trigger requirements.
* **Tests**
  * Added coverage for grouped sensor states and subscriptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->