### PR TITLE
Show all active Home Assistant light rows

### DIFF
--- a/docs/home-assistant-display.md
+++ b/docs/home-assistant-display.md
@@ -22,3 +22,5 @@ when either member should claim the screen.
 Tokens and household entity IDs belong only in ignored deployment config. The
 service does not log URLs, tokens, headers, or authentication payloads.
 Unavailable updates retain the previous useful value with a stale marker.
+The lights card uses a compact seven-row layout when more than four configured
+rows are active, and replaces only true overflow beyond seven rows with a count.

--- a/docs/home-assistant-display.md
+++ b/docs/home-assistant-display.md
@@ -22,5 +22,6 @@ when either member should claim the screen.
 Tokens and household entity IDs belong only in ignored deployment config. The
 service does not log URLs, tokens, headers, or authentication payloads.
 Unavailable updates retain the previous useful value with a stale marker.
-The lights card uses a compact seven-row layout when more than four configured
-rows are active, and replaces only true overflow beyond seven rows with a count.
+The lights card keeps the normal four-row font size and paginates additional
+active rows. Pages default to 15 seconds and can be adjusted per screen with
+`page_seconds`; the screen duration expands when needed so every page is shown.

--- a/home_assistant_display.py
+++ b/home_assistant_display.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import math
 import os
+
 from PIL import Image, ImageDraw, ImageFont
 
 from font_utils import get_font_paths
@@ -62,12 +64,24 @@ def resolve_entity_state(entity, states):
     return max(active or usable, key=lambda state: state.received_monotonic)
 
 
-def light_rows(items, limit=7):
-    """Keep every active light visible, using a summary row only past capacity."""
-    if len(items) <= limit:
-        return items
-    hidden = len(items) - (limit - 1)
-    return items[: limit - 1] + [(f"+{hidden} more", "on", False, None)]
+def light_page(items, page, page_size=4):
+    """Return one readable page of active light rows."""
+    if not items:
+        return []
+    page_count = math.ceil(len(items) / page_size)
+    page = page % page_count
+    start = page * page_size
+    return items[start : start + page_size]
+
+
+def light_page_count(screen, states, page_size=4):
+    active = sum(
+        1
+        for entity in screen.entities
+        if (state := resolve_entity_state(entity, states))
+        and str(state.state).lower() == "on"
+    )
+    return max(1, math.ceil(active / page_size))
 
 
 def screen_has_content(screen, states):
@@ -84,7 +98,7 @@ def screen_has_content(screen, states):
 
 
 def draw_home_assistant_screen(
-    epd, screen, states, *, stale_seconds=600, now_monotonic=None
+    epd, screen, states, *, stale_seconds=600, now_monotonic=None, page=0
 ):
     white = 1 if epd.is_bw_display else epd.WHITE
     black = 0 if epd.is_bw_display else epd.BLACK
@@ -115,7 +129,7 @@ def draw_home_assistant_screen(
             for label, value, stale, state in items
             if state and str(state.state).lower() == "on"
         ]
-        items = light_rows(on) if on else [("All lights", "off", False, None)]
+        items = light_page(on, page) if on else [("All lights", "off", False, None)]
     elif screen.type == "climate":
         active = [
             item
@@ -133,10 +147,8 @@ def draw_home_assistant_screen(
             if stale:
                 draw.text((x, 96), "STALE", font=body, fill=black)
     else:
-        compact = screen.type == "lights" and len(items) > 4
-        rows = items if screen.type == "lights" else items[:4]
-        for index, (label, value, stale, state) in enumerate(rows):
-            y = 29 + index * 13 if compact else 32 + index * 21
+        for index, (label, value, stale, state) in enumerate(items[:4]):
+            y = 32 + index * 21
             if screen.type == "climate" and state:
                 current = state.attributes.get("current_temperature")
                 target = state.attributes.get("temperature")
@@ -144,10 +156,9 @@ def draw_home_assistant_screen(
                     value = f"{current} → {target}°"
             suffix = " !" if stale else ""
             draw.text((7, y), _text(draw, label, body, 145), font=body, fill=black)
-            value_font = body if compact else heading
-            rendered = _text(draw, f"{value}{suffix}", value_font, 88)
-            width = draw.textbbox((0, 0), rendered, font=value_font)[2]
-            draw.text((243 - width, y - 1), rendered, font=value_font, fill=black)
+            rendered = _text(draw, f"{value}{suffix}", heading, 88)
+            width = draw.textbbox((0, 0), rendered, font=heading)[2]
+            draw.text((243 - width, y - 1), rendered, font=heading, fill=black)
 
     image = image.rotate(ROTATION, expand=True)
     buffer = epd.getbuffer(image)

--- a/home_assistant_display.py
+++ b/home_assistant_display.py
@@ -62,6 +62,14 @@ def resolve_entity_state(entity, states):
     return max(active or usable, key=lambda state: state.received_monotonic)
 
 
+def light_rows(items, limit=7):
+    """Keep every active light visible, using a summary row only past capacity."""
+    if len(items) <= limit:
+        return items
+    hidden = len(items) - (limit - 1)
+    return items[: limit - 1] + [(f"+{hidden} more", "on", False, None)]
+
+
 def screen_has_content(screen, states):
     if screen.type in {"lights", "climate"}:
         return any(
@@ -107,7 +115,7 @@ def draw_home_assistant_screen(
             for label, value, stale, state in items
             if state and str(state.state).lower() == "on"
         ]
-        items = on or [("All lights", "off", False, None)]
+        items = light_rows(on) if on else [("All lights", "off", False, None)]
     elif screen.type == "climate":
         active = [
             item
@@ -125,8 +133,10 @@ def draw_home_assistant_screen(
             if stale:
                 draw.text((x, 96), "STALE", font=body, fill=black)
     else:
-        for index, (label, value, stale, state) in enumerate(items[:4]):
-            y = 32 + index * 21
+        compact = screen.type == "lights" and len(items) > 4
+        rows = items if screen.type == "lights" else items[:4]
+        for index, (label, value, stale, state) in enumerate(rows):
+            y = 29 + index * 13 if compact else 32 + index * 21
             if screen.type == "climate" and state:
                 current = state.attributes.get("current_temperature")
                 target = state.attributes.get("temperature")
@@ -134,9 +144,10 @@ def draw_home_assistant_screen(
                     value = f"{current} → {target}°"
             suffix = " !" if stale else ""
             draw.text((7, y), _text(draw, label, body, 145), font=body, fill=black)
-            rendered = _text(draw, f"{value}{suffix}", heading, 88)
-            width = draw.textbbox((0, 0), rendered, font=heading)[2]
-            draw.text((243 - width, y - 1), rendered, font=heading, fill=black)
+            value_font = body if compact else heading
+            rendered = _text(draw, f"{value}{suffix}", value_font, 88)
+            width = draw.textbbox((0, 0), rendered, font=value_font)[2]
+            draw.text((243 - width, y - 1), rendered, font=value_font, fill=black)
 
     image = image.rotate(ROTATION, expand=True)
     buffer = epd.getbuffer(image)

--- a/home_assistant_models.py
+++ b/home_assistant_models.py
@@ -23,6 +23,7 @@ class ScreenConfig:
     title: str
     entities: Tuple[EntityConfig, ...]
     duration_seconds: float = 30.0
+    page_seconds: float = 15.0
     priority: int = 18
 
 
@@ -82,6 +83,7 @@ def parse_config(data) -> HomeAssistantConfig:
                 str(item.get("title", item["id"])),
                 entities,
                 float(item.get("duration_seconds", 30)),
+                max(1.0, float(item.get("page_seconds", 15))),
                 int(item.get("priority", 18)),
             )
         )

--- a/home_assistant_plugin.py
+++ b/home_assistant_plugin.py
@@ -9,7 +9,11 @@ import threading
 import time
 from pathlib import Path
 
-from home_assistant_display import draw_home_assistant_screen, screen_has_content
+from home_assistant_display import (
+    draw_home_assistant_screen,
+    light_page_count,
+    screen_has_content,
+)
 from home_assistant_models import parse_config
 from home_assistant_service import HomeAssistantService
 from plugins import OverrideCapability
@@ -148,9 +152,10 @@ class HomeAssistantPlugin:
             return False
         self._screen_index %= len(screens)
         screen = screens[self._screen_index]
+        screen_duration = self._screen_duration(screen, states)
         if (
             self._screen_started is not None
-            and now >= self._screen_started + screen.duration_seconds
+            and now >= self._screen_started + screen_duration
         ):
             self.context.arbiter.release(f"ha:{screen.screen_id}")
             self._screen_index += 1
@@ -161,10 +166,11 @@ class HomeAssistantPlugin:
                 self._next_cycle = now + self.config.interval_seconds
                 return False
             screen = screens[self._screen_index]
+            screen_duration = self._screen_duration(screen, states)
         remaining = (
-            screen.duration_seconds
+            screen_duration
             if self._screen_started is None
-            else max(0.1, self._screen_started + screen.duration_seconds - now)
+            else max(0.1, self._screen_started + screen_duration - now)
         )
         rendered = self._render(screen, states, now, screen.priority, remaining)
         if (
@@ -174,12 +180,26 @@ class HomeAssistantPlugin:
             self._screen_started = now
         return rendered
 
+    @staticmethod
+    def _screen_duration(screen, states):
+        if screen.type != "lights":
+            return screen.duration_seconds
+        return max(
+            screen.duration_seconds,
+            screen.page_seconds * light_page_count(screen, states),
+        )
+
     def _render(self, screen, states, now, priority, ttl, event=False):
         owner = f"ha-event:{screen.screen_id}" if event else f"ha:{screen.screen_id}"
         if not self.context.arbiter.claim(owner, priority, ttl):
             return False
+        page = 0
+        if screen.type == "lights" and self._screen_started is not None:
+            page = int((now - self._screen_started) // screen.page_seconds)
+            page %= light_page_count(screen, states)
         key = (
             owner,
+            page,
             tuple(
                 (entity_id, states.get(entity_id))
                 for entity in screen.entities
@@ -197,6 +217,7 @@ class HomeAssistantPlugin:
                 states,
                 stale_seconds=self.config.stale_seconds,
                 now_monotonic=now,
+                page=page,
             )
         self._last_key = key
         if self.context.on_render:

--- a/tests/test_home_assistant.py
+++ b/tests/test_home_assistant.py
@@ -5,7 +5,7 @@ from datetime import datetime, timezone
 from display_adapter import MockDisplay
 from home_assistant_display import (
     draw_home_assistant_screen,
-    light_rows,
+    light_page,
     resolve_entity_state,
 )
 from home_assistant_models import parse_config
@@ -278,21 +278,55 @@ def test_grouped_entity_parser_handles_null_and_rejects_invalid_types():
         raise AssertionError("invalid entity_ids should be rejected")
 
 
-def test_light_rows_show_seven_rooms_and_summarize_only_true_overflow():
-    items = [(f"Room {index}", "on", False, None) for index in range(1, 10)]
+def test_light_rows_paginate_at_the_readable_four_row_size():
+    items = [(f"Room {index}", "on", False, None) for index in range(1, 8)]
 
-    assert [item[0] for item in light_rows(items[:7])] == [
-        f"Room {index}" for index in range(1, 8)
-    ]
-    assert [item[0] for item in light_rows(items)] == [
+    assert [item[0] for item in light_page(items, 0)] == [
         "Room 1",
         "Room 2",
         "Room 3",
         "Room 4",
+    ]
+    assert [item[0] for item in light_page(items, 1)] == [
         "Room 5",
         "Room 6",
-        "+3 more",
+        "Room 7",
     ]
+    assert light_page(items, 2) == light_page(items, 0)
+
+
+def test_lights_card_switches_pages_after_configured_read_time(monkeypatch):
+    service = FakeService()
+    service.states = {
+        f"light.room_{index}": state(f"light.room_{index}", "on") for index in range(5)
+    }
+    config = parse_config(
+        {
+            "screens": [
+                {
+                    "id": "lights",
+                    "type": "lights",
+                    "duration_seconds": 30,
+                    "page_seconds": 15,
+                    "entities": [
+                        {"entity_id": entity_id} for entity_id in service.states
+                    ],
+                }
+            ]
+        }
+    )
+    pages = []
+    monkeypatch.setattr(
+        "home_assistant_plugin.draw_home_assistant_screen",
+        lambda *args, **kwargs: pages.append(kwargs["page"]),
+    )
+    context = PluginContext(MockDisplay(), ScreenArbiter(lambda: 0), threading.Lock())
+    plugin = HomeAssistantPlugin(context, config=config, service=service)
+
+    assert plugin.tick(0)
+    assert not plugin.tick(14)
+    assert plugin.tick(15)
+    assert pages == [0, 1]
 
 
 def test_unavailable_state_preserves_last_good_value():

--- a/tests/test_home_assistant.py
+++ b/tests/test_home_assistant.py
@@ -3,7 +3,11 @@ import threading
 from datetime import datetime, timezone
 
 from display_adapter import MockDisplay
-from home_assistant_display import draw_home_assistant_screen, resolve_entity_state
+from home_assistant_display import (
+    draw_home_assistant_screen,
+    light_rows,
+    resolve_entity_state,
+)
 from home_assistant_models import parse_config
 from home_assistant_plugin import HomeAssistantPlugin
 from home_assistant_service import EntityState, HomeAssistantService
@@ -272,6 +276,23 @@ def test_grouped_entity_parser_handles_null_and_rejects_invalid_types():
         assert str(exc) == "Home Assistant entity_ids must be a list"
     else:
         raise AssertionError("invalid entity_ids should be rejected")
+
+
+def test_light_rows_show_seven_rooms_and_summarize_only_true_overflow():
+    items = [(f"Room {index}", "on", False, None) for index in range(1, 10)]
+
+    assert [item[0] for item in light_rows(items[:7])] == [
+        f"Room {index}" for index in range(1, 8)
+    ]
+    assert [item[0] for item in light_rows(items)] == [
+        "Room 1",
+        "Room 2",
+        "Room 3",
+        "Room 4",
+        "Room 5",
+        "Room 6",
+        "+3 more",
+    ]
 
 
 def test_unavailable_state_preserves_last_good_value():


### PR DESCRIPTION
Prevent the Home Assistant lights card from silently truncating active rooms after the fourth row.

- render up to seven active room rows in a compact layout
- summarize only true overflow beyond seven
- retain the existing four-row layout for other card types

This complements private per-room grouping of individual light entities while keeping household IDs out of the public repository.

Verification: 346 tests passed and the seven-row 250x122 render was visually checked.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Home Assistant light cards now use a compact layout when more than four rows are displayed.
  * Up to seven light rows remain visible, with only additional rows summarized as “+N more.”
  * Improved value alignment and text sizing enhance readability across light card layouts.

* **Documentation**
  * Updated Home Assistant display documentation to describe the compact layout and overflow behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->