### PR TITLE
Reduce display logging pressure

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -40,6 +40,9 @@ display_model = epd2in13g_V2
 # Screen rotation - by default we rotate the screen 90 degrees to reach a landscape orientation. If your screen is upside down, try 270.
 screen_rotation = 90
 refresh_interval = 90
+# INFO avoids high-volume driver and HTTP diagnostics on constrained Pi storage.
+# Set to DEBUG temporarily when collecting detailed troubleshooting logs.
+display_log_level = INFO
 # Our display takes about 25 seconds to refresh, no need to refresh more often than that
 refresh_minimal_time = 30 
 # Refresh weather every 10 minutes

--- a/.env.example
+++ b/.env.example
@@ -42,7 +42,7 @@ screen_rotation = 90
 refresh_interval = 90
 # INFO avoids high-volume driver and HTTP diagnostics on constrained Pi storage.
 # Set to DEBUG temporarily when collecting detailed troubleshooting logs.
-display_log_level = INFO
+display_log_level=INFO
 # Our display takes about 25 seconds to refresh, no need to refresh more often than that
 refresh_minimal_time = 30 
 # Refresh weather every 10 minutes

--- a/display_adapter.py
+++ b/display_adapter.py
@@ -94,7 +94,7 @@ class DisplayAdapter:
                 image = image.rotate(-DISPLAY_SCREEN_ROTATION, expand=True)
                 debug_path = "debug_output.png"
                 image.save(debug_path)
-                logger.info(f"Debug image saved to {debug_path}")
+                logger.debug(f"Debug image saved to {debug_path}")
             else:
                 logger.debug(f"Skipping debug image save for unsupported type: {type(image)}")
         except Exception as e:

--- a/log_config.py
+++ b/log_config.py
@@ -5,7 +5,15 @@ from logging.handlers import RotatingFileHandler
 
 def configured_log_level(value=None):
     """Return a safe logging level for the display's constrained runtime."""
-    name = (value or os.getenv("display_log_level", "INFO")).strip().upper()
+    if value is None:
+        value = os.getenv("display_log_level", "INFO")
+    if isinstance(value, int):
+        return value
+    if not isinstance(value, str):
+        return logging.INFO
+    name = value.strip().upper()
+    if name.isdigit():
+        return int(name)
     level = getattr(logging, name, None)
     return level if isinstance(level, int) else logging.INFO
 

--- a/log_config.py
+++ b/log_config.py
@@ -2,13 +2,22 @@ import os
 import logging
 from logging.handlers import RotatingFileHandler
 
+
+def configured_log_level(value=None):
+    """Return a safe logging level for the display's constrained runtime."""
+    name = (value or os.getenv("display_log_level", "INFO")).strip().upper()
+    level = getattr(logging, name, None)
+    return level if isinstance(level, int) else logging.INFO
+
+
 # Create logs directory if it doesn't exist
 logs_dir = os.path.join(os.path.expanduser('~'), 'display_programme/logs')
 os.makedirs(logs_dir, exist_ok=True)
 
 # Set up root logger
 logger = logging.getLogger()
-logger.setLevel(logging.DEBUG)
+log_level = configured_log_level()
+logger.setLevel(log_level)
 
 # Create formatters
 console_formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
@@ -16,16 +25,16 @@ file_formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(m
 
 # Console handler
 console_handler = logging.StreamHandler()
-console_handler.setLevel(logging.DEBUG)
+console_handler.setLevel(log_level)
 console_handler.setFormatter(console_formatter)
 logger.addHandler(console_handler)
 
 # Rotating file handler
 file_handler = RotatingFileHandler(
     os.path.join(logs_dir, 'app.log'),
-    maxBytes=1024*1024,  # 1MB
+    maxBytes=1024 * 1024,  # 1MB
     backupCount=5
 )
-file_handler.setLevel(logging.DEBUG)
+file_handler.setLevel(log_level)
 file_handler.setFormatter(file_formatter)
 logger.addHandler(file_handler)

--- a/tests/test_log_config.py
+++ b/tests/test_log_config.py
@@ -1,0 +1,17 @@
+import logging
+
+from log_config import configured_log_level
+
+
+def test_configured_log_level_defaults_to_info(monkeypatch):
+    monkeypatch.delenv("display_log_level", raising=False)
+
+    assert configured_log_level() == logging.INFO
+
+
+def test_configured_log_level_accepts_named_level():
+    assert configured_log_level("warning") == logging.WARNING
+
+
+def test_configured_log_level_rejects_invalid_level():
+    assert configured_log_level("chatty") == logging.INFO

--- a/tests/test_log_config.py
+++ b/tests/test_log_config.py
@@ -13,5 +13,11 @@ def test_configured_log_level_accepts_named_level():
     assert configured_log_level("warning") == logging.WARNING
 
 
+def test_configured_log_level_accepts_integer_and_numeric_string():
+    assert configured_log_level(logging.ERROR) == logging.ERROR
+    assert configured_log_level(str(logging.CRITICAL)) == logging.CRITICAL
+
+
 def test_configured_log_level_rejects_invalid_level():
     assert configured_log_level("chatty") == logging.INFO
+    assert configured_log_level(object()) == logging.INFO


### PR DESCRIPTION
## Summary
- default the display runtime to INFO logging while preserving an explicit display_log_level override
- stop emitting every debug image save at INFO
- document the setting and cover level parsing

## Why
The constrained Pi was duplicating DEBUG output into both its rotating file and journald. The persistent journal reached 2.8 GB, while live sampling showed SD-card swap/reclaim stalls and high I/O wait.

## Validation
- 356 tests passed
- targeted flake8 clean
- git diff --check clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configurable application logging levels through the `display_log_level` setting.
  - Defaults to `INFO`, with support for temporarily enabling `DEBUG` diagnostics.
  - Invalid logging-level values safely fall back to `INFO`.

- **Bug Fixes**
  - Reduced routine debug-image save messages from informational logs to debug logs.
  - Improved handling of partial-update initialization failures.

- **Tests**
  - Added coverage for default, valid, and invalid logging-level settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->