### PR TITLE
Fix split client on Waveshare list buffers and 122px panels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,18 @@
 
 ## [Unreleased](https://github.com/bdamokos/rpi_waiting_time_display/tree/HEAD)
 
-[Full Changelog](https://github.com/bdamokos/rpi_waiting_time_display/compare/v0.3.0...HEAD)
+[Full Changelog](https://github.com/bdamokos/rpi_waiting_time_display/compare/v0.3.1...HEAD)
+
+## [v0.3.1](https://github.com/bdamokos/rpi_waiting_time_display/tree/v0.3.1) (2026-07-16)
+
+[Full Changelog](https://github.com/bdamokos/rpi_waiting_time_display/compare/v0.3.0...v0.3.1)
+
+**Fixed bugs:**
+
+- Accept list-based Waveshare partial-update buffers without converting them
+  through the driver twice.
+- Pad the validated 250x120 network frame to the physical panel's 122x250
+  hardware buffer after rotation.
 
 ## [v0.3.0](https://github.com/bdamokos/rpi_waiting_time_display/tree/v0.3.0) (2026-07-15)
 

--- a/Dockerfile.server
+++ b/Dockerfile.server
@@ -23,7 +23,7 @@ RUN mkdir -p /run/rpi-waiting-time-display /app/cache \
     && chown display:display /run/rpi-waiting-time-display /app/cache
 
 LABEL org.opencontainers.image.title="rpi-waiting-time-display render server" \
-      org.opencontainers.image.version="0.3.0" \
+      org.opencontainers.image.version="0.3.1" \
       org.opencontainers.image.source="https://github.com/bdamokos/rpi_waiting_time_display"
 
 USER display

--- a/display_adapter.py
+++ b/display_adapter.py
@@ -293,8 +293,9 @@ class DisplayAdapter:
                         logger.debug("Using native displayPartial mode")
                         # Save debug image before converting to buffer
                         DisplayAdapter.save_debug_image(image)
-                        # If image is already a bytearray, use it directly
-                        if isinstance(image, bytearray):
+                        # Waveshare drivers may return list, bytes, or bytearray
+                        # buffers. Only PIL images still need conversion.
+                        if not isinstance(image, Image.Image):
                             return original_displayPartial(image)
                         # Otherwise convert to buffer
                         return original_displayPartial(epd.getbuffer(image))
@@ -311,8 +312,9 @@ class DisplayAdapter:
                             logger.debug("Using native displayPartBaseImage mode")
                             # Save debug image before converting to buffer
                             DisplayAdapter.save_debug_image(image)
-                            # If image is already a bytearray, use it directly
-                            if isinstance(image, bytearray):
+                            # Waveshare drivers may return list, bytes, or
+                            # bytearray buffers. Only PIL images need conversion.
+                            if not isinstance(image, Image.Image):
                                 return original_displayPartBaseImage(image)
                             # Otherwise convert to buffer
                             return original_displayPartBaseImage(epd.getbuffer(image))

--- a/display_client.py
+++ b/display_client.py
@@ -242,7 +242,15 @@ class FrameClient:
                     f"({image.width}x{image.height} > "
                     f"{target_width}x{target_height})"
                 )
-            padded = Image.new("1", (target_width, target_height), 1)
+            bands = image.getbands()
+            white = 1 if image.mode == "1" else (
+                255 if len(bands) == 1 else tuple(255 for _ in bands)
+            )
+            padded = Image.new(
+                image.mode,
+                (target_width, target_height),
+                white,
+            )
             padded.paste(
                 image,
                 (

--- a/display_client.py
+++ b/display_client.py
@@ -230,6 +230,27 @@ class FrameClient:
 
     def _display(self, frame: Image.Image) -> None:
         image = frame.rotate(self.rotation, expand=True)
+        target_width = getattr(self.epd, "width", None)
+        target_height = getattr(self.epd, "height", None)
+        if target_width and target_height and image.size != (
+            target_width,
+            target_height,
+        ):
+            if image.width > target_width or image.height > target_height:
+                raise ValueError(
+                    "frame does not fit the hardware buffer "
+                    f"({image.width}x{image.height} > "
+                    f"{target_width}x{target_height})"
+                )
+            padded = Image.new("1", (target_width, target_height), 1)
+            padded.paste(
+                image,
+                (
+                    (target_width - image.width) // 2,
+                    (target_height - image.height) // 2,
+                ),
+            )
+            image = padded
         with self.display_lock:
             use_base = self.displayed_updates % self.full_refresh_every == 0
             if use_base and self.displayed_updates > 0:

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -4,6 +4,7 @@ from display_adapter import DisplayAdapter, MockDisplay, return_display_lock
 from threading import Lock
 from unittest.mock import patch
 import os
+from types import SimpleNamespace
 
 @pytest.fixture
 def mock_display():
@@ -109,3 +110,43 @@ def test_getbuffer_wrapper(mock_display):
     assert buffer is not None
     assert buffer is test_image
     mock_save.assert_called_once_with(test_image)
+
+
+@patch('display_adapter.importlib.import_module')
+def test_partial_wrappers_accept_waveshare_list_buffers(mock_import, monkeypatch):
+    """A Waveshare list buffer must not be passed through getbuffer twice."""
+
+    class FakeEPD:
+        BLACK = 0x00
+        WHITE = 0xFF
+
+        def __init__(self):
+            self.base_images = []
+            self.partial_images = []
+
+        def init(self):
+            return None
+
+        def getbuffer(self, image):
+            assert isinstance(image, Image.Image)
+            return [0xFF]
+
+        def displayPartial(self, image):
+            self.partial_images.append(image)
+
+        def displayPartBaseImage(self, image):
+            self.base_images.append(image)
+
+    monkeypatch.setenv('display_model', 'fake')
+    mock_import.return_value = SimpleNamespace(
+        EPD=FakeEPD,
+        epdconfig=SimpleNamespace(module_exit=lambda cleanup=True: None),
+    )
+
+    display = DisplayAdapter.get_display()
+    buffer = display.getbuffer(Image.new('1', (122, 250), 1))
+    display.displayPartBaseImage(buffer)
+    display.displayPartial(buffer)
+
+    assert display.base_images == [[0xFF]]
+    assert display.partial_images == [[0xFF]]

--- a/tests/test_display_client.py
+++ b/tests/test_display_client.py
@@ -113,6 +113,23 @@ def test_client_validates_displays_and_uses_conditional_request(monkeypatch):
     assert not_modified.closed
 
 
+def test_client_pads_network_frame_to_physical_panel_width():
+    display = FakeDisplay()
+    display.width = 122
+    display.height = 250
+    client = FrameClient(
+        display,
+        url="http://server/api/v1/frame.png",
+        session=FakeSession([frame_response()]),
+        clock=lambda: NOW,
+    )
+
+    assert client.poll_once().status == "displayed"
+    assert display.base[0].size == (122, 250)
+    assert display.base[0].getpixel((0, 0)) == 1
+    assert display.base[0].getpixel((121, 249)) == 1
+
+
 def test_client_rejects_not_modified_before_first_frame():
     response = FakeResponse(
         status=304,

--- a/tests/test_display_client.py
+++ b/tests/test_display_client.py
@@ -130,6 +130,19 @@ def test_client_pads_network_frame_to_physical_panel_width():
     assert display.base[0].getpixel((121, 249)) == 1
 
 
+def test_client_padding_preserves_multiband_image_mode():
+    display = FakeDisplay()
+    display.width = 122
+    display.height = 250
+    client = FrameClient(display, url="http://server/api/v1/frame.png")
+
+    client._display(Image.new("RGB", (250, 120), (0, 0, 0)))
+
+    assert display.base[0].mode == "RGB"
+    assert display.base[0].getpixel((0, 0)) == (255, 255, 255)
+    assert display.base[0].getpixel((121, 249)) == (255, 255, 255)
+
+
 def test_client_rejects_not_modified_before_first_frame():
     response = FakeResponse(
         status=304,

--- a/tests/test_display_server.py
+++ b/tests/test_display_server.py
@@ -17,7 +17,7 @@ def test_health_readiness_auth_and_conditional_frame(tmp_path, monkeypatch):
 
     health = client.get("/healthz").get_json()
     assert health["sequence"] is None
-    assert health["version"] == "0.3.0"
+    assert health["version"] == "0.3.1"
     assert client.get("/readyz").status_code == 503
     assert client.get("/api/v1/frame.png").status_code == 401
 

--- a/version.py
+++ b/version.py
@@ -1,3 +1,3 @@
 """Project version shared by packaging and runtime health metadata."""
 
-__version__ = "0.3.0"
+__version__ = "0.3.1"


### PR DESCRIPTION
## Summary

- accept Waveshare list/bytes buffers without attempting a second PIL conversion
- pad the validated 250x120 network frame to the physical panel buffer dimensions after rotation
- add regression coverage for the real `epd2in13_V4` list-buffer and 122x250 hardware behavior

## Validation

- public branch: 407 tests passed
- deployment/private branch: 420 tests passed
- physical Raspberry Pi Zero: `display-client.service` active, systemd notify watchdog 45s, restart count 0, successive sequences displayed, no final-start dimension warnings or service errors
- RS2 render server unchanged and healthy at private `77e3fb2`

This fixes the hardware-only failures discovered during the v0.3.0 split-client deployment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with display buffers provided as lists, bytes, and other non-image formats.
  * Frames are now automatically centered and padded to match the connected display’s physical dimensions.
  * Oversized frames now produce a clear error instead of being rendered incorrectly.

* **Tests**
  * Added coverage for alternate display buffers and frame padding behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->