### PR TITLE
Add bounded split-client outage diagnostic

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -64,6 +64,14 @@ display_client_poll_interval=5
 display_client_timeout=5
 display_client_max_frame_age=300
 display_client_full_refresh_every=40
+# Keep verified pixels through transient failures, then show a tiny local-only
+# diagnostic. Runtime bounds: 30-86400 seconds and 30-3600 seconds respectively.
+display_client_diagnostic_after=300
+display_client_diagnostic_cadence=60
+# Standard systemd-timesyncd marker. While absent, diagnostics explicitly avoid
+# presenting the wall clock as synchronized. Leave blank only when an external
+# startup gate guarantees that the local clock is already synchronized.
+display_client_clock_sync_path=/run/systemd/timesync/synchronized
 # Secondary diagnostics are tmpfs-only; set blank to disable.
 display_client_health_path=/run/rpi-waiting-time-display/client-health.json
 

--- a/display_client.py
+++ b/display_client.py
@@ -418,6 +418,15 @@ def bounded_env_seconds(
     return min(maximum, max(minimum, float(os.getenv(name, str(default)))))
 
 
+def clock_sync_marker_present(path: str) -> bool:
+    if not path:
+        return True
+    try:
+        return Path(path).exists()
+    except OSError:
+        return False
+
+
 def render_diagnostic_view(view: DiagnosticView) -> Image.Image:
     """Render with Pillow's tiny built-in font; no remote or heavy assets."""
     image = Image.new("1", (250, 120), 1)
@@ -454,8 +463,6 @@ class OutageDiagnosticController:
         self._outage_started: float | None = None
         self._last_success: float | None = None
         self._last_rendered: float | None = None
-        self._last_render_category: str | None = None
-        self._last_render_sync: bool | None = None
         self._last_monotonic: float | None = None
         self._stopped = False
 
@@ -469,8 +476,6 @@ class OutageDiagnosticController:
         self._last_success = now
         self._outage_started = None
         self._last_rendered = None
-        self._last_render_category = None
-        self._last_render_sync = None
 
     def record_failure(self, exc: BaseException) -> bool:
         if self._stopped:
@@ -493,8 +498,6 @@ class OutageDiagnosticController:
         due = (
             self._last_rendered is None
             or now - self._last_rendered >= self.cadence_seconds
-            or category != self._last_render_category
-            or synchronized != self._last_render_sync
         )
         if not due or self._stopped:
             return False
@@ -509,8 +512,6 @@ class OutageDiagnosticController:
             return False
         self.client.display_local_diagnostic(render_diagnostic_view(view))
         self._last_rendered = now
-        self._last_render_category = category
-        self._last_render_sync = synchronized
         return True
 
     def shutdown(self) -> None:
@@ -574,8 +575,7 @@ def main() -> int:
         client,
         threshold_seconds=diagnostic_threshold,
         cadence_seconds=diagnostic_cadence,
-        clock_synchronized=lambda: not clock_sync_path
-        or Path(clock_sync_path).exists(),
+        clock_synchronized=lambda: clock_sync_marker_present(clock_sync_path),
     )
     last_attempt_at = None
     last_success_at = None

--- a/display_client.py
+++ b/display_client.py
@@ -13,11 +13,12 @@ import tempfile
 import threading
 import time
 from dataclasses import asdict, dataclass
+from datetime import datetime
 from pathlib import Path
 
 import dotenv
 import requests
-from PIL import Image
+from PIL import Image, ImageDraw, ImageFont
 
 from display_adapter import initialize_display, return_display_lock
 from display_protocol import MAX_FRAME_BYTES, parse_utc, utc_now, validate_frame_bytes
@@ -30,6 +31,15 @@ class PollResult:
     status: str
     sequence: int | None = None
     frame_source_created_at: str | None = None
+
+
+@dataclass(frozen=True)
+class DiagnosticView:
+    """Sanitized local-only content for a prolonged render-server outage."""
+
+    category: str
+    clock_synchronized: bool
+    lines: tuple[str, ...]
 
 
 class SystemdNotifier:
@@ -139,6 +149,9 @@ class FrameClient:
             1, int(os.getenv("display_client_full_refresh_every", "40"))
         )
         self.displayed_updates = 0
+        self._has_displayed_anything = False
+        self.last_verified_frame: Image.Image | None = None
+        self.diagnostic_displayed = False
         self.display_lock = return_display_lock()
 
     def _headers(self) -> dict[str, str]:
@@ -165,9 +178,16 @@ class FrameClient:
                     raise ValueError("not-modified response omitted frame timestamp")
                 self._validate_freshness(created_at)
                 self.last_frame_created_at = created_at
-                return PollResult(
-                    "not-modified", self.last_sequence or None, created_at
-                )
+                status = "not-modified"
+                if self.diagnostic_displayed:
+                    if self.last_verified_frame is None:
+                        raise ValueError(
+                            "not-modified response cannot restore a verified frame"
+                        )
+                    self._display(self.last_verified_frame)
+                    self.diagnostic_displayed = False
+                    status = "restored"
+                return PollResult(status, self.last_sequence or None, created_at)
             response.raise_for_status()
             content_type = response.headers.get("Content-Type", "").split(";", 1)[0]
             if content_type != "image/png":
@@ -200,6 +220,8 @@ class FrameClient:
                 raise ValueError("frame digest does not match response")
             frame = validate_frame_bytes(content)
             self._display(frame)
+            self.last_verified_frame = frame.copy()
+            self.diagnostic_displayed = False
             self.last_sequence = sequence
             self.etag = response.headers.get("ETag")
             self.last_frame_created_at = created_at
@@ -228,13 +250,23 @@ class FrameClient:
         if age > self.max_frame_age_seconds:
             raise ValueError(f"frame is stale ({age:.1f}s old)")
 
-    def _display(self, frame: Image.Image) -> None:
+    def display_local_diagnostic(self, frame: Image.Image) -> None:
+        """Display a locally generated frame without changing protocol state."""
+        self._display(frame, count_server_update=False)
+        self.diagnostic_displayed = True
+
+    def _display(self, frame: Image.Image, *, count_server_update: bool = True) -> None:
         image = frame.rotate(self.rotation, expand=True)
         target_width = getattr(self.epd, "width", None)
         target_height = getattr(self.epd, "height", None)
-        if target_width and target_height and image.size != (
-            target_width,
-            target_height,
+        if (
+            target_width
+            and target_height
+            and image.size
+            != (
+                target_width,
+                target_height,
+            )
         ):
             if image.width > target_width or image.height > target_height:
                 raise ValueError(
@@ -243,8 +275,10 @@ class FrameClient:
                     f"{target_width}x{target_height})"
                 )
             bands = image.getbands()
-            white = 1 if image.mode == "1" else (
-                255 if len(bands) == 1 else tuple(255 for _ in bands)
+            white = (
+                1
+                if image.mode == "1"
+                else (255 if len(bands) == 1 else tuple(255 for _ in bands))
             )
             padded = Image.new(
                 image.mode,
@@ -260,8 +294,11 @@ class FrameClient:
             )
             image = padded
         with self.display_lock:
-            use_base = self.displayed_updates % self.full_refresh_every == 0
-            if use_base and self.displayed_updates > 0:
+            use_base = not self._has_displayed_anything or (
+                count_server_update
+                and self.displayed_updates % self.full_refresh_every == 0
+            )
+            if use_base and self._has_displayed_anything:
                 self.epd.init()
                 self.epd.Clear()
                 self.epd.init_Fast()
@@ -273,7 +310,211 @@ class FrameClient:
                     self.epd.displayPartial(buffer)
             else:
                 self.epd.display(buffer)
-            self.displayed_updates += 1
+            self._has_displayed_anything = True
+            if count_server_update:
+                self.displayed_updates += 1
+
+
+def categorize_poll_error(exc: BaseException) -> str:
+    """Return a short stable category without leaking request details."""
+    if isinstance(exc, requests.Timeout):
+        return "timeout"
+    if isinstance(exc, requests.HTTPError):
+        status = getattr(getattr(exc, "response", None), "status_code", None)
+        if status in (401, 403):
+            return "auth"
+        if status in (408, 504):
+            return "timeout"
+        return "server"
+    if isinstance(exc, requests.ConnectionError):
+        if _exception_contains(exc, socket.gaierror):
+            return "dns"
+        return "connection"
+
+    message = str(exc).lower()
+    if "too far in the future" in message or "future timestamp" in message:
+        return "future-timestamp"
+    if "stale" in message:
+        return "stale"
+    if "401" in message or "403" in message:
+        return "auth"
+    return "protocol"
+
+
+def _exception_contains(exc: BaseException, target: type[BaseException]) -> bool:
+    pending = [exc]
+    seen = set()
+    while pending:
+        current = pending.pop()
+        if id(current) in seen:
+            continue
+        seen.add(id(current))
+        if isinstance(current, target):
+            return True
+        for linked in (current.__cause__, current.__context__, *current.args):
+            if isinstance(linked, BaseException):
+                pending.append(linked)
+    return False
+
+
+def build_diagnostic_view(
+    category: str,
+    *,
+    local_now: datetime,
+    seconds_since_success: float | None,
+    clock_synchronized: bool,
+) -> DiagnosticView:
+    safe_category = (
+        category
+        if category
+        in {
+            "auth",
+            "connection",
+            "dns",
+            "future-timestamp",
+            "protocol",
+            "server",
+            "stale",
+            "timeout",
+        }
+        else "protocol"
+    )
+    if clock_synchronized:
+        time_line = f"Local: {local_now.strftime('%Y-%m-%d %H:%M %Z')}"
+    else:
+        time_line = "Local time: not synchronized"
+    if seconds_since_success is None:
+        last_frame_line = "Last frame: not seen this boot"
+    else:
+        last_frame_line = f"Last frame: {_format_elapsed(seconds_since_success)} ago"
+    return DiagnosticView(
+        category=safe_category,
+        clock_synchronized=clock_synchronized,
+        lines=(
+            "RENDER SERVER UNAVAILABLE",
+            time_line,
+            last_frame_line,
+            f"Error: {safe_category}",
+        ),
+    )
+
+
+def _format_elapsed(seconds: float) -> str:
+    total_minutes = max(0, int(seconds)) // 60
+    if total_minutes < 1:
+        return "less than 1m"
+    if total_minutes < 60:
+        return f"{total_minutes}m"
+    hours, minutes = divmod(total_minutes, 60)
+    if hours < 24:
+        return f"{hours}h {minutes}m" if minutes else f"{hours}h"
+    days, hours = divmod(hours, 24)
+    return f"{days}d {hours}h" if hours else f"{days}d"
+
+
+def bounded_env_seconds(
+    name: str, default: float, *, minimum: float, maximum: float
+) -> float:
+    return min(maximum, max(minimum, float(os.getenv(name, str(default)))))
+
+
+def render_diagnostic_view(view: DiagnosticView) -> Image.Image:
+    """Render with Pillow's tiny built-in font; no remote or heavy assets."""
+    image = Image.new("1", (250, 120), 1)
+    draw = ImageDraw.Draw(image)
+    font = ImageFont.load_default()
+    draw.rectangle((0, 0, 249, 22), fill=0)
+    draw.text((6, 6), view.lines[0], font=font, fill=1)
+    for y, line in zip((34, 55, 76), view.lines[1:]):
+        draw.text((6, y), line, font=font, fill=0)
+    draw.line((6, 99, 243, 99), fill=0)
+    draw.text((6, 104), "Retrying verified frames", font=font, fill=0)
+    return image
+
+
+class OutageDiagnosticController:
+    """Monotonic, low-cadence policy for prolonged local fallback."""
+
+    def __init__(
+        self,
+        client: FrameClient,
+        *,
+        threshold_seconds: float = 300,
+        cadence_seconds: float = 60,
+        monotonic_clock=time.monotonic,
+        local_clock=lambda: datetime.now().astimezone(),
+        clock_synchronized=lambda: True,
+    ) -> None:
+        self.client = client
+        self.threshold_seconds = max(0.0, threshold_seconds)
+        self.cadence_seconds = max(0.0, cadence_seconds)
+        self.monotonic_clock = monotonic_clock
+        self.local_clock = local_clock
+        self.clock_synchronized = clock_synchronized
+        self._outage_started: float | None = None
+        self._last_success: float | None = None
+        self._last_rendered: float | None = None
+        self._last_render_category: str | None = None
+        self._last_render_sync: bool | None = None
+        self._last_monotonic: float | None = None
+        self._stopped = False
+
+    @property
+    def diagnostic_active(self) -> bool:
+        return self.client.diagnostic_displayed
+
+    def record_success(self) -> None:
+        now = self.monotonic_clock()
+        self._last_monotonic = now
+        self._last_success = now
+        self._outage_started = None
+        self._last_rendered = None
+        self._last_render_category = None
+        self._last_render_sync = None
+
+    def record_failure(self, exc: BaseException) -> bool:
+        if self._stopped:
+            return False
+        now = self.monotonic_clock()
+        if self._last_monotonic is not None and now < self._last_monotonic:
+            # Treat a monotonic rollback like a new boot. Never accelerate the
+            # fallback because either wall or monotonic time moved abruptly.
+            self._outage_started = now
+            self._last_success = None
+            self._last_rendered = None
+        self._last_monotonic = now
+        if self._outage_started is None:
+            self._outage_started = now
+        if now - self._outage_started < self.threshold_seconds:
+            return False
+
+        category = categorize_poll_error(exc)
+        synchronized = bool(self.clock_synchronized())
+        due = (
+            self._last_rendered is None
+            or now - self._last_rendered >= self.cadence_seconds
+            or category != self._last_render_category
+            or synchronized != self._last_render_sync
+        )
+        if not due or self._stopped:
+            return False
+        elapsed = None if self._last_success is None else now - self._last_success
+        view = build_diagnostic_view(
+            category,
+            local_now=self.local_clock(),
+            seconds_since_success=elapsed,
+            clock_synchronized=synchronized,
+        )
+        if self._stopped:
+            return False
+        self.client.display_local_diagnostic(render_diagnostic_view(view))
+        self._last_rendered = now
+        self._last_render_category = category
+        self._last_render_sync = synchronized
+        return True
+
+    def shutdown(self) -> None:
+        self._stopped = True
 
 
 def client_display_cleanup(epd) -> None:
@@ -313,6 +554,29 @@ def main() -> int:
             "/run/rpi-waiting-time-display/client-health.json",
         )
     )
+    diagnostic_threshold = bounded_env_seconds(
+        "display_client_diagnostic_after",
+        300,
+        minimum=30,
+        maximum=86400,
+    )
+    diagnostic_cadence = bounded_env_seconds(
+        "display_client_diagnostic_cadence",
+        60,
+        minimum=30,
+        maximum=3600,
+    )
+    clock_sync_path = os.getenv(
+        "display_client_clock_sync_path",
+        "/run/systemd/timesync/synchronized",
+    )
+    outage_diagnostic = OutageDiagnosticController(
+        client,
+        threshold_seconds=diagnostic_threshold,
+        cadence_seconds=diagnostic_cadence,
+        clock_synchronized=lambda: not clock_sync_path
+        or Path(clock_sync_path).exists(),
+    )
     last_attempt_at = None
     last_success_at = None
     last_error_at = None
@@ -320,12 +584,15 @@ def main() -> int:
     shutdown_event = threading.Event()
 
     def stop(_signum=None, _frame=None):
+        outage_diagnostic.shutdown()
         shutdown_event.set()
 
     signal.signal(signal.SIGTERM, stop)
     signal.signal(signal.SIGINT, stop)
-    notifier.notify("STATUS=Display initialized; waiting for a fresh frame")
-    ready_sent = False
+    notifier.notify(
+        "READY=1",
+        "STATUS=Display initialized; waiting for a fresh frame",
+    )
     try:
         while not shutdown_event.is_set():
             started = time.monotonic()
@@ -333,26 +600,36 @@ def main() -> int:
             try:
                 result = client.poll_once()
                 logger.debug("Frame poll result: %s", result.status)
+                outage_diagnostic.record_success()
                 last_success_at = utc_now().isoformat()
                 last_error = None
-                notifications = [
+                notifier.notify(
                     "WATCHDOG=1",
                     f"STATUS=Fresh frame sequence {result.sequence} ({result.status})",
-                ]
-                if not ready_sent:
-                    notifications.insert(0, "READY=1")
-                    ready_sent = True
-                notifier.notify(*notifications)
+                )
                 state = "healthy"
             except (requests.RequestException, ValueError, KeyError) as exc:
-                # Offline/stale policy: keep the last verified pixels. Never
-                # replace them with an error page, partial response, or old PNG.
+                if shutdown_event.is_set():
+                    break
+                category = categorize_poll_error(exc)
+                diagnostic_updated = outage_diagnostic.record_failure(exc)
                 logger.warning(
-                    "Frame poll rejected; retaining last good display: %s", exc
+                    "Frame poll rejected; retaining safe display (category=%s)",
+                    category,
                 )
                 last_error_at = utc_now().isoformat()
-                last_error = str(exc)
-                notifier.notify(f"STATUS=Frame poll failed: {exc}")
+                last_error = category
+                fallback = (
+                    "local diagnostic active"
+                    if outage_diagnostic.diagnostic_active
+                    else "retaining last verified pixels"
+                )
+                notifier.notify(
+                    "WATCHDOG=1",
+                    f"STATUS=Frame poll failed ({category}); {fallback}",
+                )
+                if diagnostic_updated:
+                    logger.info("Updated local outage diagnostic (%s)", category)
                 state = "degraded"
             health_reporter.write(
                 ClientHealth(

--- a/docs/display-watchdog.md
+++ b/docs/display-watchdog.md
@@ -25,11 +25,16 @@ detector:
   `StartLimitBurst=3`, and `StartLimitAction=none`; service recovery uses
   `Restart=on-failure`, `RestartSec=10`, `TimeoutStartSec=60`, and
   `TimeoutStopSec=30`.
-- Its main loop sends `READY=1` only after hardware initialization and the first
-  successful fresh `200` or `304` frame response.
-- That same main loop sends `WATCHDOG=1` only after each subsequent successful
-  fresh `200` or `304`. A `200` succeeds only after the display update; a `304`
-  preserves the already-verified frame.
+- Its main loop sends `READY=1` after hardware initialization. Fresh-frame
+  readiness remains independently visible in the client health file and
+  secondary auditor rather than blocking service startup through a server
+  outage.
+- That same main loop sends `WATCHDOG=1` after each completed bounded poll,
+  including a safely classified rejection. A `200` succeeds only after the
+  validated display update; a fresh `304` preserves or restores the in-memory
+  verified frame. Rejected data never updates protocol state or reaches the
+  panel; after the configured threshold the client may instead draw its tiny
+  local-only outage diagnostic.
 - No helper or timer sends keepalives. A client thread wedged in rendering,
   lock acquisition, SPI, or I/O therefore cannot be hidden by a healthy helper.
 - Clean shutdown does not clear the e-paper. Whole-host `RuntimeWatchdogSec`,

--- a/docs/split-server-client.md
+++ b/docs/split-server-client.md
@@ -33,8 +33,13 @@ replacements succeed. The client rejects wrong content types, invalid or
 oversized PNGs, non-`250x120` dimensions, digest/length mismatches, stale or
 future timestamps, and backward sequences without a newer server epoch.
 
-When the network or server is unavailable, the client keeps the last verified
-pixels. It never displays an HTTP error body or an unverified/stale image.
+When the network or server is briefly unavailable, the client keeps the last
+verified pixels. After a bounded local outage threshold it replaces those
+pixels with a tiny locally generated diagnostic containing only local time,
+time since the last success when known, and a stable error category. It never
+displays an HTTP error body or an unverified/stale image. The next verified
+server response restores the verified frame immediately, including a `304`
+for the in-memory last verified frame.
 
 ## Security model
 
@@ -103,7 +108,30 @@ display_client_poll_interval=1
 display_client_timeout=5
 display_client_max_frame_age=300
 display_client_full_refresh_every=40
+display_client_diagnostic_after=300
+display_client_diagnostic_cadence=60
+display_client_clock_sync_path=/run/systemd/timesync/synchronized
 ```
+
+`display_client_diagnostic_after` defaults to five minutes and is bounded to
+30 seconds through 24 hours. Shorter failures retain the exact last-good
+pixels. `display_client_diagnostic_cadence` defaults to one minute and is
+bounded to 30 seconds through one hour; the local frame is not regenerated on
+each network poll. An error-category or clock-synchronization state change may
+trigger an immediate update. The diagnostic uses only Pillow's built-in bitmap
+font and local drawing primitives—no assets, browser, server, extra loop, or
+network probe.
+
+Threshold and cadence decisions use the monotonic clock, so wall-clock steps
+cannot accelerate the transition. By default the client checks the local
+systemd-timesyncd marker at
+`/run/systemd/timesync/synchronized`. While that marker is absent, the screen
+says `Local time: not synchronized` instead of presenting a potentially false
+time. Set `display_client_clock_sync_path` to the marker used by the host's
+time-sync startup gate, or leave it blank only when that external gate
+guarantees synchronization before client startup. Future/stale timestamp
+validation remains active either way; the marker does not bypass any frame
+check.
 
 Then stage and activate during an approved deployment window:
 
@@ -120,11 +148,14 @@ systemctl status display-client.service
 client from being restarted indefinitely: after three failed starts or
 watchdog terminations in six hours, systemd leaves the client stopped without
 escalating to a host action. The main poll loop sends `READY=1` after hardware
-initialization and its first successful fresh frame result, then sends
-`WATCHDOG=1` only after each successful, fresh `200` or `304` result. A
-separate helper cannot mask a wedged loop. Systemd may restart this client
-service after a watchdog failure; this project does not configure a whole-host
-hardware watchdog, reboot, or power cycle.
+initialization and services `WATCHDOG=1` after every completed bounded poll,
+including a safely classified rejection. This distinguishes client-loop health
+from render-server health: rejected data still cannot alter protocol state or
+be displayed, while a server outage no longer creates a client restart loop.
+A wedged request or display write still misses the watchdog because there is no
+separate helper thread to mask it. Systemd may restart this client service
+after a watchdog failure; this project does not configure a whole-host hardware
+watchdog, reboot, or power cycle.
 
 The client uses partial updates and establishes a base image on its first
 frame. It performs a hardware full/base refresh every
@@ -137,6 +168,8 @@ changes to `/run/rpi-waiting-time-display/client-health.json` (tmpfs). Schema
 version 1 fields are: `role`, `boot_id`, `pid`, `state`, `sequence`, `etag`,
 `last_attempt_at`, `last_success_at`, `last_error_at`, `error`,
 `frame_source_created_at`, `server_generated_at`, and `server_received_at`.
+On failures, `error` is the same sanitized stable category used by the local
+diagnostic rather than a URL-bearing exception string.
 Set `display_client_health_path=` to disable this secondary file.
 An external auditor may read this file and systemd state for diagnostics, but
 for a notify-guarded client it must remain observation-only. The service's

--- a/docs/split-server-client.md
+++ b/docs/split-server-client.md
@@ -37,9 +37,10 @@ When the network or server is briefly unavailable, the client keeps the last
 verified pixels. After a bounded local outage threshold it replaces those
 pixels with a tiny locally generated diagnostic containing only local time,
 time since the last success when known, and a stable error category. It never
-displays an HTTP error body or an unverified/stale image. The next verified
-server response restores the verified frame immediately, including a `304`
-for the in-memory last verified frame.
+displays an HTTP error body. Retained last-verified pixels may age in place, but
+the client never accepts or renders a newly arrived response unless it is
+verified and fresh. The next verified server response restores the verified
+frame immediately, including a `304` for the in-memory last verified frame.
 
 ## Security model
 
@@ -117,10 +118,10 @@ display_client_clock_sync_path=/run/systemd/timesync/synchronized
 30 seconds through 24 hours. Shorter failures retain the exact last-good
 pixels. `display_client_diagnostic_cadence` defaults to one minute and is
 bounded to 30 seconds through one hour; the local frame is not regenerated on
-each network poll. An error-category or clock-synchronization state change may
-trigger an immediate update. The diagnostic uses only Pillow's built-in bitmap
-font and local drawing primitives—no assets, browser, server, extra loop, or
-network probe.
+each network poll. Error-category and clock-synchronization changes are
+coalesced until that hard cadence allows the next update. The diagnostic uses
+only Pillow's built-in bitmap font and local drawing primitives—no assets,
+browser, server, extra loop, or network probe.
 
 Threshold and cadence decisions use the monotonic clock, so wall-clock steps
 cannot accelerate the transition. By default the client checks the local

--- a/tests/test_display_client.py
+++ b/tests/test_display_client.py
@@ -18,6 +18,7 @@ from display_client import (
     bounded_env_seconds,
     build_diagnostic_view,
     categorize_poll_error,
+    clock_sync_marker_present,
 )
 
 NOW = datetime(2026, 7, 15, 12, 0, tzinfo=timezone.utc)
@@ -323,7 +324,7 @@ def test_diagnostic_threshold_and_cadence_configuration_are_bounded(monkeypatch)
     assert bounded_env_seconds("missing", 60, minimum=30, maximum=3600) == 60
 
 
-def test_outage_diagnostic_updates_at_low_cadence_or_category_change():
+def test_outage_diagnostic_hard_limits_category_changes_to_low_cadence():
     display = FakeDisplay()
     client = FrameClient(display, url="http://server/frame.png")
     monotonic = MutableClock(0.0)
@@ -345,11 +346,13 @@ def test_outage_diagnostic_updates_at_low_cadence_or_category_change():
     assert diagnostic.record_failure(requests.Timeout())
     assert len(display.base) + len(display.partial) == 2
     monotonic.value = 361.0
+    assert not diagnostic.record_failure(ValueError("frame is stale (301.0s old)"))
+    monotonic.value = 420.0
     assert diagnostic.record_failure(ValueError("frame is stale (301.0s old)"))
     assert len(display.base) + len(display.partial) == 3
 
 
-def test_clock_sync_change_updates_diagnostic_without_waiting_for_cadence():
+def test_clock_sync_change_is_coalesced_until_diagnostic_cadence():
     display = FakeDisplay()
     client = FrameClient(display, url="http://server/frame.png")
     monotonic = MutableClock(0.0)
@@ -368,9 +371,21 @@ def test_clock_sync_change_updates_diagnostic_without_waiting_for_cadence():
     assert diagnostic.record_failure(requests.Timeout())
     synchronized.value = True
     monotonic.value = 301.0
+    assert not diagnostic.record_failure(requests.Timeout())
+    monotonic.value = 360.0
     assert diagnostic.record_failure(requests.Timeout())
 
     assert len(display.base) + len(display.partial) == 2
+
+
+def test_clock_sync_marker_errors_are_safe_and_unsynchronized(monkeypatch):
+    def fail_exists(_path):
+        raise PermissionError("private path details")
+
+    monkeypatch.setattr("display_client.Path.exists", fail_exists)
+
+    assert not clock_sync_marker_present("/run/systemd/timesync/synchronized")
+    assert clock_sync_marker_present("")
 
 
 @pytest.mark.parametrize(

--- a/tests/test_display_client.py
+++ b/tests/test_display_client.py
@@ -9,7 +9,16 @@ import pytest
 import requests
 from PIL import Image
 
-from display_client import ClientHealth, FrameClient, HealthReporter, SystemdNotifier
+from display_client import (
+    ClientHealth,
+    FrameClient,
+    HealthReporter,
+    OutageDiagnosticController,
+    SystemdNotifier,
+    bounded_env_seconds,
+    build_diagnostic_view,
+    categorize_poll_error,
+)
 
 NOW = datetime(2026, 7, 15, 12, 0, tzinfo=timezone.utc)
 
@@ -73,6 +82,14 @@ class FakeDisplay:
 
     def displayPartial(self, image):
         self.partial.append(image.copy())
+
+
+class MutableClock:
+    def __init__(self, value):
+        self.value = value
+
+    def __call__(self):
+        return self.value
 
 
 def frame_response(sequence=1, created_at=NOW, content=None):
@@ -246,6 +263,267 @@ def test_client_periodically_uses_full_base_refresh(monkeypatch):
     assert len(display.base) == 2
     assert len(display.partial) == 1
     assert display.events == ["init", "clear", "fast"]
+
+
+def test_transient_outage_retains_last_good_pixels():
+    display = FakeDisplay()
+    client = FrameClient(
+        display,
+        url="http://server/frame.png",
+        session=FakeSession([frame_response()]),
+        clock=lambda: NOW,
+    )
+    monotonic = MutableClock(100.0)
+    diagnostic = OutageDiagnosticController(
+        client, threshold_seconds=300, monotonic_clock=monotonic
+    )
+
+    client.poll_once()
+    diagnostic.record_success()
+    last_good = display.base[0].copy()
+    monotonic.value = 101.0
+    assert not diagnostic.record_failure(requests.Timeout("private endpoint"))
+    monotonic.value = 399.9
+    assert not diagnostic.record_failure(requests.Timeout("private endpoint"))
+
+    assert len(display.base) == 1
+    assert not display.partial
+    assert display.base[0].tobytes() == last_good.tobytes()
+
+
+def test_outage_threshold_transitions_to_local_diagnostic():
+    display = FakeDisplay()
+    client = FrameClient(display, url="http://server/frame.png")
+    monotonic = MutableClock(10.0)
+    diagnostic = OutageDiagnosticController(
+        client,
+        threshold_seconds=300,
+        cadence_seconds=60,
+        monotonic_clock=monotonic,
+        local_clock=lambda: NOW,
+    )
+
+    assert not diagnostic.record_failure(requests.Timeout())
+    monotonic.value = 309.9
+    assert not diagnostic.record_failure(requests.Timeout())
+    monotonic.value = 310.0
+    assert diagnostic.record_failure(requests.Timeout())
+
+    assert diagnostic.diagnostic_active
+    assert len(display.base) == 1
+    assert display.base[0].size == (120, 250)
+
+
+def test_diagnostic_threshold_and_cadence_configuration_are_bounded(monkeypatch):
+    monkeypatch.setenv("short", "1")
+    monkeypatch.setenv("long", "999999")
+
+    assert bounded_env_seconds("short", 300, minimum=30, maximum=86400) == 30
+    assert bounded_env_seconds("long", 60, minimum=30, maximum=3600) == 3600
+    assert bounded_env_seconds("missing", 60, minimum=30, maximum=3600) == 60
+
+
+def test_outage_diagnostic_updates_at_low_cadence_or_category_change():
+    display = FakeDisplay()
+    client = FrameClient(display, url="http://server/frame.png")
+    monotonic = MutableClock(0.0)
+    diagnostic = OutageDiagnosticController(
+        client,
+        threshold_seconds=300,
+        cadence_seconds=60,
+        monotonic_clock=monotonic,
+        local_clock=lambda: NOW,
+    )
+
+    diagnostic.record_failure(requests.Timeout())
+    monotonic.value = 300.0
+    assert diagnostic.record_failure(requests.Timeout())
+    monotonic.value = 359.9
+    assert not diagnostic.record_failure(requests.Timeout())
+    assert len(display.base) + len(display.partial) == 1
+    monotonic.value = 360.0
+    assert diagnostic.record_failure(requests.Timeout())
+    assert len(display.base) + len(display.partial) == 2
+    monotonic.value = 361.0
+    assert diagnostic.record_failure(ValueError("frame is stale (301.0s old)"))
+    assert len(display.base) + len(display.partial) == 3
+
+
+def test_clock_sync_change_updates_diagnostic_without_waiting_for_cadence():
+    display = FakeDisplay()
+    client = FrameClient(display, url="http://server/frame.png")
+    monotonic = MutableClock(0.0)
+    synchronized = MutableClock(False)
+    diagnostic = OutageDiagnosticController(
+        client,
+        threshold_seconds=300,
+        cadence_seconds=60,
+        monotonic_clock=monotonic,
+        local_clock=lambda: NOW,
+        clock_synchronized=synchronized,
+    )
+
+    diagnostic.record_failure(requests.Timeout())
+    monotonic.value = 300.0
+    assert diagnostic.record_failure(requests.Timeout())
+    synchronized.value = True
+    monotonic.value = 301.0
+    assert diagnostic.record_failure(requests.Timeout())
+
+    assert len(display.base) + len(display.partial) == 2
+
+
+@pytest.mark.parametrize(
+    "exc, expected",
+    [
+        (requests.Timeout("http://secret-host/token"), "timeout"),
+        (
+            requests.ConnectionError(socket.gaierror(-2, "private.example")),
+            "dns",
+        ),
+        (requests.ConnectionError("192.168.1.2 refused"), "connection"),
+        (ValueError("frame is stale (999s old)"), "stale"),
+        (ValueError("frame timestamp is too far in the future"), "future-timestamp"),
+        (ValueError("token=do-not-display"), "protocol"),
+    ],
+)
+def test_poll_errors_are_reduced_to_sanitized_categories(exc, expected):
+    category = categorize_poll_error(exc)
+    view = build_diagnostic_view(
+        category,
+        local_now=NOW,
+        seconds_since_success=900,
+        clock_synchronized=True,
+    )
+
+    assert category == expected
+    rendered_text = " ".join(view.lines)
+    assert "secret-host" not in rendered_text
+    assert "192.168" not in rendered_text
+    assert "do-not-display" not in rendered_text
+
+
+def test_http_auth_error_has_stable_sanitized_category():
+    response = requests.Response()
+    response.status_code = 403
+    error = requests.HTTPError("403 for private URL", response=response)
+
+    assert categorize_poll_error(error) == "auth"
+
+
+def test_diagnostic_view_includes_local_time_and_last_success_age():
+    view = build_diagnostic_view(
+        "timeout",
+        local_now=NOW,
+        seconds_since_success=900,
+        clock_synchronized=True,
+    )
+
+    assert view.lines[1] == "Local: 2026-07-15 12:00 UTC"
+    assert view.lines[2] == "Last frame: 15m ago"
+
+
+def test_verified_not_modified_response_restores_frame_after_diagnostic():
+    display = FakeDisplay()
+    not_modified = FakeResponse(
+        status=304,
+        headers={"X-Display-Published-At": NOW.isoformat()},
+    )
+    client = FrameClient(
+        display,
+        url="http://server/frame.png",
+        session=FakeSession([frame_response(), not_modified]),
+        clock=lambda: NOW,
+    )
+    monotonic = MutableClock(0.0)
+    diagnostic = OutageDiagnosticController(
+        client,
+        threshold_seconds=30,
+        monotonic_clock=monotonic,
+        local_clock=lambda: NOW,
+    )
+
+    client.poll_once()
+    diagnostic.record_success()
+    verified_pixels = display.base[0].tobytes()
+    monotonic.value = 1.0
+    diagnostic.record_failure(requests.Timeout())
+    monotonic.value = 31.0
+    assert diagnostic.record_failure(requests.Timeout())
+    assert client.last_sequence == 1
+    assert client.etag == '"1-etag"'
+    assert client.poll_once().status == "restored"
+
+    assert not client.diagnostic_displayed
+    assert display.partial[-1].tobytes() == verified_pixels
+
+
+def test_wall_clock_jump_does_not_accelerate_threshold_and_unsynced_is_explicit():
+    display = FakeDisplay()
+    client = FrameClient(display, url="http://server/frame.png")
+    monotonic = MutableClock(0.0)
+    wall = MutableClock(NOW)
+    diagnostic = OutageDiagnosticController(
+        client,
+        threshold_seconds=300,
+        monotonic_clock=monotonic,
+        local_clock=wall,
+        clock_synchronized=lambda: False,
+    )
+
+    diagnostic.record_failure(ValueError("frame timestamp is too far in the future"))
+    wall.value = NOW + timedelta(days=3650)
+    monotonic.value = 1.0
+    assert not diagnostic.record_failure(
+        ValueError("frame timestamp is too far in the future")
+    )
+    monotonic.value = 300.0
+    assert diagnostic.record_failure(
+        ValueError("frame timestamp is too far in the future")
+    )
+    view = build_diagnostic_view(
+        "future-timestamp",
+        local_now=wall.value,
+        seconds_since_success=None,
+        clock_synchronized=False,
+    )
+
+    assert "not synchronized" in view.lines[1]
+    assert "2036" not in " ".join(view.lines)
+
+
+def test_monotonic_rollback_restarts_outage_threshold_safely():
+    display = FakeDisplay()
+    client = FrameClient(display, url="http://server/frame.png")
+    monotonic = MutableClock(1000.0)
+    diagnostic = OutageDiagnosticController(
+        client, threshold_seconds=300, monotonic_clock=monotonic
+    )
+
+    diagnostic.record_failure(requests.Timeout())
+    monotonic.value = 900.0
+    assert not diagnostic.record_failure(requests.Timeout())
+    monotonic.value = 1199.9
+    assert not diagnostic.record_failure(requests.Timeout())
+    monotonic.value = 1200.0
+    assert diagnostic.record_failure(requests.Timeout())
+
+
+def test_shutdown_prevents_later_diagnostic_writes():
+    display = FakeDisplay()
+    client = FrameClient(display, url="http://server/frame.png")
+    monotonic = MutableClock(0.0)
+    diagnostic = OutageDiagnosticController(
+        client, threshold_seconds=30, monotonic_clock=monotonic
+    )
+
+    diagnostic.record_failure(requests.Timeout())
+    diagnostic.shutdown()
+    monotonic.value = 30.0
+
+    assert not diagnostic.record_failure(requests.Timeout())
+    assert not display.base
+    assert not display.partial
 
 
 def test_health_reporter_is_atomic_tmpfs_contract_and_deduplicates(tmp_path):


### PR DESCRIPTION
## Summary

- retain the last verified e-paper frame through short render-server failures
- transition after a bounded configurable outage to a tiny local-only diagnostic with synchronized local time, last-success age, and a sanitized error category
- rate-limit diagnostic redraws and immediately restore the next verified server frame, including authenticated `304 Not Modified` recovery
- separate client-loop watchdog health from server-frame health so an outage does not create a restart loop
- document conservative defaults and compatibility with the bounded time-sync startup gate

## Safety

The fallback does not modify frame authentication, digest, dimensions, freshness, future-timestamp, or rollback validation. It does not display response bodies, URLs, tokens, IP addresses, exception details, remote assets, or household data. Outage timing uses the monotonic clock; an unsynchronized wall clock is labeled explicitly.

## Validation

- `68 passed` focused split-client/protocol/server/watchdog tests
- `426 passed` full test suite
- Black check
- isort check with Black profile
- `git diff --check`
- All three actionable review threads resolved

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added local outage diagnostics after configurable network or server failures.
  * Preserves the last verified display and restores it when service resumes, including after unchanged responses.
  * Shows sanitized error categories, elapsed time, and clock-synchronization status.
  * Added configuration for diagnostic timing, refresh cadence, and clock-sync marker location.
  * Watchdog and health reporting now reflect bounded polling and categorized errors.

* **Documentation**
  * Updated watchdog and client behavior documentation for recovery, diagnostics, and clock synchronization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->