### PR TITLE
Add progressive font growth for content screens

### DIFF
--- a/breaking_news_display.py
+++ b/breaking_news_display.py
@@ -2,7 +2,9 @@
 
 from PIL import Image, ImageDraw
 
-from rss_display import _ellipsize, _finish, _fonts, _wrap
+from font_utils import get_font_paths
+from rss_display import _ellipsize, _finish, _fonts
+from text_layout import fit_wrapped_text
 
 
 def draw_breaking_news(epd, entry, *, set_base_image=False):
@@ -24,6 +26,21 @@ def draw_breaking_news(epd, entry, *, set_base_image=False):
     source = _ellipsize(draw, entry.publication.upper(), tiny, 236)
     draw.text((7, 31), source, font=tiny, fill=black)
     draw.line((7, 44, 243, 44), fill=black, width=1)
-    for index, line in enumerate(_wrap(draw, entry.title, title_font, 236, 4)):
-        draw.text((7, 50 + index * 17), line, font=title_font, fill=black)
+    fitted = fit_wrapped_text(
+        draw,
+        entry.title,
+        get_font_paths()["dejavu_bold"],
+        min_size=14,
+        max_size=24,
+        max_width=236,
+        max_height=66,
+        max_lines=4,
+    )
+    for index, line in enumerate(fitted.lines):
+        draw.text(
+            (7, 50 + index * fitted.line_advance),
+            line,
+            font=fitted.font,
+            fill=black,
+        )
     _finish(epd, image, set_base_image)

--- a/calendar_display.py
+++ b/calendar_display.py
@@ -202,9 +202,7 @@ def draw_calendar_agenda(
         y = 29 + index * row_height
         label = _event_time_label(event, now)
         draw.text((7, y + (row_height - 12) // 2), label, font=tiny, fill=black)
-        block_height = (len(fitted.lines) - 1) * fitted.line_advance
-        block_height += draw.textbbox((0, 0), "Ag", font=fitted.font)[3]
-        title_y = y + max(0, (row_height - block_height) // 2)
+        title_y = y + max(0, (row_height - fitted.height) // 2)
         for line_index, line in enumerate(fitted.lines):
             draw.text(
                 (82, title_y + line_index * fitted.line_advance),

--- a/calendar_display.py
+++ b/calendar_display.py
@@ -13,6 +13,7 @@ from PIL import Image, ImageDraw, ImageFont
 from calendar_service import CalendarEvent
 from display_adapter import return_display_lock
 from font_utils import get_font_paths
+from text_layout import fit_wrapped_text
 
 display_lock = return_display_lock()
 DISPLAY_SCREEN_ROTATION = int(os.getenv("screen_rotation", 90))
@@ -109,8 +110,23 @@ def draw_upcoming_event(
     draw.text((243 - status_width, 7), status, font=tiny, fill=black)
     draw.line((7, 24, 243, 24), fill=black, width=1)
 
-    for index, line in enumerate(_wrap_two_lines(draw, event.summary, title_font, 236)):
-        draw.text((7, 29 + index * 17), line, font=title_font, fill=black)
+    summary = fit_wrapped_text(
+        draw,
+        event.summary,
+        get_font_paths()["dejavu_bold"],
+        min_size=15,
+        max_size=24,
+        max_width=236,
+        max_height=34 if event.location else 48,
+        max_lines=2,
+    )
+    for index, line in enumerate(summary.lines):
+        draw.text(
+            (7, 29 + index * summary.line_advance),
+            line,
+            font=summary.font,
+            fill=black,
+        )
     if event.location:
         location = _ellipsize(draw, event.location, tiny, 236)
         draw.text((7, 65), location, font=tiny, fill=black)
@@ -149,12 +165,55 @@ def draw_calendar_agenda(
     draw.text((243 - status_width, 7), status, font=tiny, fill=black)
     draw.line((7, 24, 243, 24), fill=black, width=1)
 
-    for index, event in enumerate(events[:4]):
-        y = 29 + index * 23
+    visible_events = events[:4]
+    fitted_titles = []
+    if visible_events:
+        row_height = 88 // len(visible_events)
+        max_title_size = {1: 28, 2: 22, 3: 18, 4: 15}[len(visible_events)]
+        fitted_titles = [
+            fit_wrapped_text(
+                draw,
+                event.summary,
+                get_font_paths()["dejavu_bold"],
+                min_size=15,
+                max_size=max_title_size,
+                max_width=160,
+                max_height=row_height - 4,
+                max_lines=3 if len(visible_events) == 1 else 2,
+            )
+            for event in visible_events
+        ]
+        common_size = min(item.size for item in fitted_titles)
+        fitted_titles = [
+            fit_wrapped_text(
+                draw,
+                event.summary,
+                get_font_paths()["dejavu_bold"],
+                min_size=common_size,
+                max_size=common_size,
+                max_width=160,
+                max_height=row_height - 4,
+                max_lines=3 if len(visible_events) == 1 else 2,
+            )
+            for event in visible_events
+        ]
+
+    for index, (event, fitted) in enumerate(zip(visible_events, fitted_titles)):
+        y = 29 + index * row_height
         label = _event_time_label(event, now)
-        draw.text((7, y + 2), label, font=tiny, fill=black)
-        title = _ellipsize(draw, event.summary, title_font, 160)
-        draw.text((82, y), title, font=title_font, fill=black)
-        if index < min(len(events), 4) - 1:
-            draw.line((7, y + 20, 243, y + 20), fill=black, width=1)
+        draw.text((7, y + (row_height - 12) // 2), label, font=tiny, fill=black)
+        block_height = (len(fitted.lines) - 1) * fitted.line_advance
+        block_height += draw.textbbox((0, 0), "Ag", font=fitted.font)[3]
+        title_y = y + max(0, (row_height - block_height) // 2)
+        for line_index, line in enumerate(fitted.lines):
+            draw.text(
+                (82, title_y + line_index * fitted.line_advance),
+                line,
+                font=fitted.font,
+                fill=black,
+            )
+        if index < len(visible_events) - 1:
+            draw.line(
+                (7, y + row_height - 1, 243, y + row_height - 1), fill=black, width=1
+            )
     _finish(epd, image, set_base_image)

--- a/font_utils.py
+++ b/font_utils.py
@@ -107,7 +107,10 @@ def get_font_paths():
         user_fonts = os.path.expanduser('~/Library/Fonts')
 
         def first_existing(*candidates):
-            return next(path for path in candidates if os.path.isfile(path))
+            return next(
+                (path for path in candidates if os.path.isfile(path)),
+                candidates[0],
+            )
 
         return {
             'dejavu': first_existing(

--- a/font_utils.py
+++ b/font_utils.py
@@ -104,9 +104,22 @@ def get_font_paths():
     system = platform.system()
 
     if system == "Darwin":  # macOS
+        user_fonts = os.path.expanduser('~/Library/Fonts')
+
+        def first_existing(*candidates):
+            return next(path for path in candidates if os.path.isfile(path))
+
         return {
-            'dejavu': '/System/Library/Fonts/Supplemental/DejaVuSans.ttf',
-            'dejavu_bold': '/System/Library/Fonts/Supplemental/DejaVuSans-Bold.ttf',
+            'dejavu': first_existing(
+                os.path.join(user_fonts, 'DejaVuSans.ttf'),
+                '/System/Library/Fonts/Supplemental/DejaVuSans.ttf',
+                '/System/Library/Fonts/Supplemental/Arial.ttf',
+            ),
+            'dejavu_bold': first_existing(
+                os.path.join(user_fonts, 'DejaVuSans-Bold.ttf'),
+                '/System/Library/Fonts/Supplemental/DejaVuSans-Bold.ttf',
+                '/System/Library/Fonts/Supplemental/Arial Bold.ttf',
+            ),
             'emoji': os.path.expanduser('~/Library/Fonts/NotoEmoji[wght].ttf')  # Use user's Noto Emoji font
         }
     else:  # Assume Raspberry Pi/Linux

--- a/rss_display.py
+++ b/rss_display.py
@@ -10,6 +10,7 @@ from PIL import Image, ImageDraw, ImageFont, ImageOps
 
 from display_adapter import return_display_lock
 from font_utils import get_font_paths
+from text_layout import fit_wrapped_text
 
 display_lock = return_display_lock()
 DISPLAY_SCREEN_ROTATION = int(os.getenv("screen_rotation", "90"))
@@ -113,13 +114,41 @@ def draw_feed_entry(epd, entry, *, avatar_bytes=None, set_base_image=False):
         )
         y, max_lines = 48, 4
         width = 243 - left if left > 7 else 236
-        for index, line in enumerate(
-            _wrap(draw, entry.title, body_font, width, max_lines)
-        ):
-            draw.text((left, y + index * 14), line, font=body_font, fill=black)
+        fitted = fit_wrapped_text(
+            draw,
+            entry.title,
+            get_font_paths()["dejavu"],
+            min_size=11,
+            max_size=20,
+            max_width=width,
+            max_height=68,
+            max_lines=max_lines,
+        )
+        for index, line in enumerate(fitted.lines):
+            draw.text(
+                (left, y + index * fitted.line_advance),
+                line,
+                font=fitted.font,
+                fill=black,
+            )
     else:
-        for index, line in enumerate(_wrap(draw, entry.title, title_font, 236, 4)):
-            draw.text((7, 31 + index * 18), line, font=title_font, fill=black)
+        fitted = fit_wrapped_text(
+            draw,
+            entry.title,
+            get_font_paths()["dejavu_bold"],
+            min_size=14,
+            max_size=24,
+            max_width=236,
+            max_height=69 if entry.author else 85,
+            max_lines=4,
+        )
+        for index, line in enumerate(fitted.lines):
+            draw.text(
+                (7, 31 + index * fitted.line_advance),
+                line,
+                font=fitted.font,
+                fill=black,
+            )
         if entry.author:
             draw.text(
                 (7, 104),

--- a/tests/test_text_layout.py
+++ b/tests/test_text_layout.py
@@ -1,0 +1,61 @@
+from PIL import Image, ImageDraw
+
+from font_utils import get_font_paths
+from text_layout import fit_wrapped_text
+
+
+def _draw():
+    return ImageDraw.Draw(Image.new("1", (250, 120), 1))
+
+
+def test_short_text_grows_to_maximum_size():
+    fitted = fit_wrapped_text(
+        _draw(),
+        "Short update",
+        get_font_paths()["dejavu_bold"],
+        min_size=11,
+        max_size=24,
+        max_width=236,
+        max_height=70,
+        max_lines=4,
+    )
+
+    assert fitted.size == 24
+    assert fitted.lines == ("Short update",)
+    assert not fitted.truncated
+
+
+def test_longer_text_uses_largest_size_that_fits_without_truncation():
+    fitted = fit_wrapped_text(
+        _draw(),
+        "A longer update that needs several lines but still fits in its content area",
+        get_font_paths()["dejavu"],
+        min_size=11,
+        max_size=24,
+        max_width=180,
+        max_height=60,
+        max_lines=4,
+    )
+
+    assert 11 <= fitted.size < 24
+    assert " ".join(fitted.lines) == (
+        "A longer update that needs several lines but still fits in its content area"
+    )
+    assert not fitted.truncated
+
+
+def test_overflow_at_minimum_size_is_ellipsized():
+    fitted = fit_wrapped_text(
+        _draw(),
+        "This text is deliberately much too long for one very narrow line",
+        get_font_paths()["dejavu"],
+        min_size=11,
+        max_size=18,
+        max_width=80,
+        max_height=15,
+        max_lines=1,
+    )
+
+    assert fitted.size == 11
+    assert fitted.truncated
+    assert fitted.lines[-1].endswith("…")

--- a/tests/test_text_layout.py
+++ b/tests/test_text_layout.py
@@ -22,6 +22,7 @@ def test_short_text_grows_to_maximum_size():
 
     assert fitted.size == 24
     assert fitted.lines == ("Short update",)
+    assert fitted.height > 0
     assert not fitted.truncated
 
 

--- a/tests/test_text_layout.py
+++ b/tests/test_text_layout.py
@@ -60,3 +60,20 @@ def test_overflow_at_minimum_size_is_ellipsized():
     assert fitted.size == 11
     assert fitted.truncated
     assert fitted.lines[-1].endswith("…")
+
+
+def test_unbreakable_overflow_keeps_visible_ellipsized_text():
+    fitted = fit_wrapped_text(
+        _draw(),
+        "averylongunbreakableidentifier",
+        get_font_paths()["dejavu"],
+        min_size=11,
+        max_size=18,
+        max_width=50,
+        max_height=60,
+        max_lines=4,
+    )
+
+    assert fitted.truncated
+    assert fitted.lines[0]
+    assert fitted.lines[0].endswith("…")

--- a/text_layout.py
+++ b/text_layout.py
@@ -16,6 +16,7 @@ class FittedText:
     lines: tuple[str, ...]
     line_advance: int
     size: int
+    height: int
     truncated: bool = False
 
 
@@ -111,10 +112,11 @@ def fit_wrapped_text(
         )
         visible = lines[:line_limit]
         if truncated:
-            remainder = " ".join(lines[line_limit - 1:])
-            visible[-1] = _ellipsize(draw, remainder, font, max_width)
-        return FittedText(font, tuple(visible), advance, min_size, truncated)
+            visible[-1] = _ellipsize(draw, visible[-1] + "…", font, max_width)
+        height = (len(visible) - 1) * advance + bottom
+        return FittedText(font, tuple(visible), advance, min_size, height, truncated)
 
+    first_font = None
     best = None
     for size in range(min_size, max_size + 1):
         try:
@@ -123,6 +125,8 @@ def fit_wrapped_text(
             # A bitmap fallback cannot be progressively resized. Return it as
             # the minimum-size layout instead of pretending it reached max_size.
             return minimum_result(ImageFont.load_default())
+        if first_font is None:
+            first_font = font
         lines = _wrap_all(draw, text, font, max_width)
         fits, advance = _fits(
             draw, lines, font, max_width, max_height, max_lines, spacing
@@ -130,15 +134,13 @@ def fit_wrapped_text(
         if not fits:
             # Larger fonts cannot recover width, height, or line-count space.
             break
-        best = FittedText(font, tuple(lines), advance, size)
+        _, bottom = _line_metrics(draw, font, spacing)
+        height = (len(lines) - 1) * advance + bottom if lines else 0
+        best = FittedText(font, tuple(lines), advance, size, height)
         if not hasattr(font, "size"):
             break
 
     if best is not None:
         return best
 
-    try:
-        font = _truetype(font_path, min_size)
-    except OSError:
-        font = ImageFont.load_default()
-    return minimum_result(font)
+    return minimum_result(first_font)

--- a/text_layout.py
+++ b/text_layout.py
@@ -1,0 +1,144 @@
+"""Reusable text fitting helpers for bounded e-paper content areas."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from functools import lru_cache
+
+from PIL import ImageDraw, ImageFont
+
+
+@dataclass(frozen=True)
+class FittedText:
+    """A font and wrapped lines selected to fit a rectangular content area."""
+
+    font: ImageFont.ImageFont
+    lines: tuple[str, ...]
+    line_advance: int
+    size: int
+    truncated: bool = False
+
+
+@lru_cache(maxsize=128)
+def _truetype(font_path: str, size: int):
+    return ImageFont.truetype(font_path, size)
+
+
+def _normalize(text: str) -> str:
+    return " ".join(str(text).split())
+
+
+def _ellipsize(draw, text: str, font, max_width: int) -> str:
+    text = _normalize(text)
+    if draw.textbbox((0, 0), text, font=font)[2] <= max_width:
+        return text
+    suffix = "…"
+    while text and draw.textbbox((0, 0), text + suffix, font=font)[2] > max_width:
+        text = text[:-1]
+    return text.rstrip() + suffix if text else suffix
+
+
+def _wrap_all(draw, text: str, font, max_width: int) -> list[str]:
+    words = _normalize(text).split()
+    lines: list[str] = []
+    current = ""
+    for word in words:
+        candidate = f"{current} {word}".strip()
+        if current and draw.textbbox((0, 0), candidate, font=font)[2] > max_width:
+            lines.append(current)
+            current = word
+        else:
+            current = candidate
+    if current:
+        lines.append(current)
+    return lines
+
+
+def _line_metrics(draw, font, spacing: int) -> tuple[int, int]:
+    bounds = draw.textbbox((0, 0), "Ag", font=font)
+    line_bottom = max(1, bounds[3])
+    line_advance = max(1, bounds[3] - bounds[1] + spacing)
+    return line_advance, line_bottom
+
+
+def _fits(draw, lines, font, max_width, max_height, max_lines, spacing):
+    if not lines:
+        return True, 1
+    if max_lines is not None and len(lines) > max_lines:
+        return False, 1
+    if any(draw.textbbox((0, 0), line, font=font)[2] > max_width for line in lines):
+        return False, 1
+    advance, bottom = _line_metrics(draw, font, spacing)
+    height = (len(lines) - 1) * advance + bottom
+    return height <= max_height, advance
+
+
+def fit_wrapped_text(
+    draw: ImageDraw.ImageDraw,
+    text: str,
+    font_path: str,
+    *,
+    min_size: int,
+    max_size: int,
+    max_width: int,
+    max_height: int,
+    max_lines: int | None = None,
+    spacing: int = 2,
+) -> FittedText:
+    """Choose the largest font that contains all text inside the given bounds.
+
+    Font sizes are tried progressively from ``min_size`` through ``max_size``.
+    If the text cannot fit even at the minimum, the minimum-size result is
+    clipped to the available line count and ellipsized.
+    """
+
+    if min_size <= 0 or max_size < min_size:
+        raise ValueError("font sizes must satisfy 0 < min_size <= max_size")
+    if max_width <= 0 or max_height <= 0:
+        raise ValueError("text bounds must be positive")
+    if max_lines is not None and max_lines <= 0:
+        raise ValueError("max_lines must be positive")
+
+    def minimum_result(font) -> FittedText:
+        lines = _wrap_all(draw, text, font, max_width) or [""]
+        advance, bottom = _line_metrics(draw, font, spacing)
+        height_lines = max(1, 1 + max(0, max_height - bottom) // advance)
+        line_limit = (
+            min(height_lines, max_lines) if max_lines is not None else height_lines
+        )
+        truncated = len(lines) > line_limit or any(
+            draw.textbbox((0, 0), line, font=font)[2] > max_width for line in lines
+        )
+        visible = lines[:line_limit]
+        if truncated:
+            remainder = " ".join(lines[line_limit - 1:])
+            visible[-1] = _ellipsize(draw, remainder, font, max_width)
+        return FittedText(font, tuple(visible), advance, min_size, truncated)
+
+    best = None
+    for size in range(min_size, max_size + 1):
+        try:
+            font = _truetype(font_path, size)
+        except OSError:
+            # A bitmap fallback cannot be progressively resized. Return it as
+            # the minimum-size layout instead of pretending it reached max_size.
+            return minimum_result(ImageFont.load_default())
+        lines = _wrap_all(draw, text, font, max_width)
+        fits, advance = _fits(
+            draw, lines, font, max_width, max_height, max_lines, spacing
+        )
+        if not fits:
+            # Larger fonts cannot recover width, height, or line-count space.
+            break
+        best = FittedText(font, tuple(lines), advance, size)
+        if not hasattr(font, "size"):
+            break
+
+    if best is not None:
+        return best
+
+    try:
+        font = _truetype(font_path, min_size)
+    except OSError:
+        font = ImageFont.load_default()
+    return minimum_result(font)


### PR DESCRIPTION
## What changed

- add a reusable bounded text fitter that progressively selects the largest font size that fits
- apply adaptive typography to Tweets/RSS posts, breaking-news headlines, upcoming calendar events, and sparse calendar agendas
- preserve the established minimum sizes and ellipsize only when content cannot fit at the minimum
- keep fixed-layout dashboards unchanged
- resolve usable DejaVu/Arial font paths explicitly on macOS

## Why

Short free-text content previously used the same compact typography as dense content, leaving much of the 250×120 e-paper canvas unused. Content-led cards can now become more glanceable without risking overflow on longer text.

## Validation

- 439 tests passed
- focused Flake8 checks passed
- `git diff --check` passed
- representative short calendar, agenda, Tweet, and breaking-news frames visually inspected at native display dimensions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved breaking-news, calendar, and RSS headline rendering with automatic text sizing and wrapping.
  * Long titles now fit available display space more effectively, with improved line spacing and alignment.
  * Added graceful truncation with ellipses when text cannot fit.
  * Improved font discovery on macOS, including support for user-installed fonts.

* **Tests**
  * Added coverage for text sizing, wrapping, fitting, and overflow behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->