### PR TITLE
Add configurable vacation privacy mode

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -145,6 +145,16 @@ display_override_api_token=
 display_override_duration_seconds=300
 display_override_priority=30
 
+# Vacation privacy mode suppresses selected displays during inclusive local-date
+# ranges. Leave blackout dates empty to use the enabled switch as a manual
+# always-on privacy mode. Display names accept shell-style wildcards; simple
+# family names such as calendar also match calendar-event and calendar-agenda.
+vacation_mode_enabled=false
+vacation_mode_sensitive_displays=calendar,token,ynab
+vacation_mode_blackout_dates=
+vacation_mode_timezone=UTC
+vacation_mode_fallback_mode=transit
+
 # Optional read-only calendar display. The bounded Google API source is
 # recommended on the Pi. Keep credentials and calendar identifiers only in the
 # ignored .env and in files outside this repository.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@ This is a Raspberry Pi project that displays bus waiting times on an e-Paper dis
 
 ## Development Environment
 
-**Python Version**: Python 3.x
+**Python Version**: Python 3.9+
 **Main Dependencies**: Flask, Pillow, requests, RPi.GPIO, waveshare-epd, pytest
 
 For development on Mac (without hardware):

--- a/basic.py
+++ b/basic.py
@@ -466,20 +466,21 @@ class DisplayManager:
     def _scheduled_mode(self, current_time):
         scheduled_mode = self.display_schedule.mode_at(current_time)
         privacy = self._vacation_privacy()
-        if privacy.blocks(scheduled_mode, current_time):
-            return privacy.safe_fallback(current_time)
+        if privacy.blocks(scheduled_mode):
+            return privacy.safe_fallback()
         if scheduled_mode in {"ynab", "ynab-always"}:
             if not self.ynab_client.enabled:
-                return self._ynab_fallback_mode()
-            return (
+                return self._privacy_safe_mode(self._ynab_fallback_mode())
+            result = (
                 scheduled_mode
                 if self.ynab_client.get_snapshot()
                 else self._ynab_fallback_mode()
             )
+            return self._privacy_safe_mode(result)
         if scheduled_mode not in {"token", "token-always"}:
             return scheduled_mode
         if not self.token_usage_client.enabled:
-            return self._token_fallback_mode()
+            return self._privacy_safe_mode(self._token_fallback_mode())
         snapshot = self.token_usage_client.get_snapshot()
         if snapshot and not snapshot.stale and (
             scheduled_mode == "token-always"
@@ -487,17 +488,19 @@ class DisplayManager:
             or getattr(snapshot, "reset_notice", None)
         ):
             return scheduled_mode
-        return self._token_fallback_mode()
+        return self._privacy_safe_mode(self._token_fallback_mode())
 
-    def _enforce_vacation_privacy(self, current_time):
+    def _privacy_safe_mode(self, mode):
         privacy = self._vacation_privacy()
-        if not privacy.is_active(current_time):
+        return privacy.safe_fallback() if privacy.blocks(mode) else mode
+
+    def _enforce_vacation_privacy(self):
+        privacy = self._vacation_privacy()
+        if not privacy.is_active():
             return False
         override_blocked = False
         with self._override_lock:
-            if self._override_module and privacy.blocks(
-                self._override_module, current_time
-            ):
+            if self._override_module and privacy.blocks(self._override_module):
                 self._override_generation += 1
                 self._override_module = None
                 override_blocked = self.screen_arbiter.release(
@@ -506,9 +509,7 @@ class DisplayManager:
         # active_owner() also prunes plugin claims that became sensitive when
         # a blackout date started.
         self.screen_arbiter.active_owner()
-        current_blocked = privacy.blocks(
-            self.current_display_mode or "", current_time
-        )
+        current_blocked = privacy.blocks(self.current_display_mode or "")
         if override_blocked or current_blocked:
             self._last_screen_owner = None
             return True
@@ -1082,16 +1083,27 @@ class DisplayManager:
                     self.last_display_update = current_time
                     return True
                 if self._is_ynab_mode(scheduled_mode):
-                    scheduled_mode = self._ynab_fallback_mode()
+                    scheduled_mode = self._privacy_safe_mode(
+                        self._ynab_fallback_mode()
+                    )
                 if self._is_token_mode(scheduled_mode) and self._draw_token_usage(
                     current_time, require_active=scheduled_mode == "token"
                 ):
                     self.last_display_update = current_time
                     return True
                 if self._is_token_mode(scheduled_mode):
-                    scheduled_mode = self._token_fallback_mode()
+                    scheduled_mode = self._privacy_safe_mode(
+                        self._token_fallback_mode()
+                    )
+                if scheduled_mode is None:
+                    logger.info(
+                        "Vacation privacy retained the last frame because no safe "
+                        "built-in fallback is available"
+                    )
+                    return False
                 bus_data, error_message, stop_name = self.bus_manager.get_bus_data()
                 weather_data = self.weather_manager.get_weather_data() if weather_enabled else None
+                privacy = self._vacation_privacy()
                 
                 valid_bus_data = [
                     bus for bus in bus_data 
@@ -1099,7 +1111,12 @@ class DisplayManager:
                 ]
                 
                 # Check if we have any bus data at all
-                if scheduled_mode == "weather" and weather_enabled and weather_data:
+                if (
+                    scheduled_mode == "weather"
+                    and weather_enabled
+                    and weather_data
+                    and not privacy.blocks("weather")
+                ):
                     logger.info("Initial display: scheduled weather mode")
                     draw_weather_display(
                         self.epd,
@@ -1108,7 +1125,13 @@ class DisplayManager:
                     )
                     self.in_weather_mode = True
                     self.current_display_mode = "weather"
-                elif not bus_data and not error_message and weather_enabled and weather_data:
+                elif (
+                    not bus_data
+                    and not error_message
+                    and weather_enabled
+                    and weather_data
+                    and not privacy.blocks("weather")
+                ):
                     logger.info("Initial display: no bus data available, showing weather data")
                     if not self.in_weather_mode:
                         # We're switching to weather mode, set base image for partial updates
@@ -1117,7 +1140,11 @@ class DisplayManager:
                         self.current_display_mode = "weather"
                     else:
                         draw_weather_display(self.epd, weather_data)
-                elif valid_bus_data and not error_message:
+                elif (
+                    valid_bus_data
+                    and not error_message
+                    and not privacy.blocks("transit")
+                ):
                     logger.info(f"Initial display: showing bus data ({len(valid_bus_data)} entries)")
                     if self.in_weather_mode:
                         # We're switching from weather mode, set base image for partial updates
@@ -1127,7 +1154,11 @@ class DisplayManager:
                     else:
                         update_display(self.epd, weather_data, valid_bus_data, error_message, stop_name)
                         self.current_display_mode = "transit"
-                elif weather_enabled and weather_data:
+                elif (
+                    weather_enabled
+                    and weather_data
+                    and not privacy.blocks("weather")
+                ):
                     logger.info("Initial display: showing weather data")
                     if not self.in_weather_mode:
                         # We're switching to weather mode, set base image for partial updates
@@ -1200,7 +1231,7 @@ class DisplayManager:
                             self.screen_arbiter.release(self.FLIGHT_SCREEN_OWNER)
                             logger.info(f"Starting flight cooldown period of {self.flight_mode_cooldown} seconds")
 
-                if self._enforce_vacation_privacy(current_time):
+                if self._enforce_vacation_privacy():
                     self._force_display_update()
                     self._schedule_next_update()
 
@@ -1263,7 +1294,9 @@ class DisplayManager:
                                 logger.info("YNAB display updated successfully")
                                 scheduled_mode = "rendered"
                             else:
-                                scheduled_mode = self._ynab_fallback_mode()
+                                scheduled_mode = self._privacy_safe_mode(
+                                    self._ynab_fallback_mode()
+                                )
                         if self._is_token_mode(scheduled_mode):
                             if self._draw_token_usage(
                                 current_time,
@@ -1273,11 +1306,19 @@ class DisplayManager:
                                 logger.info("Token usage display updated successfully")
                                 scheduled_mode = "rendered"
                             else:
-                                scheduled_mode = self._token_fallback_mode()
+                                scheduled_mode = self._privacy_safe_mode(
+                                    self._token_fallback_mode()
+                                )
+                        privacy = self._vacation_privacy()
                         # Check if we have any bus data at all
                         if scheduled_mode == "rendered":
                             pass
-                        elif scheduled_mode == "weather" and weather_enabled and weather_data:
+                        elif (
+                            scheduled_mode == "weather"
+                            and weather_enabled
+                            and weather_data
+                            and not privacy.blocks("weather")
+                        ):
                             logger.info("Updating scheduled weather display...")
                             draw_weather_display(
                                 self.epd,
@@ -1289,7 +1330,13 @@ class DisplayManager:
                             self.last_weather_data = weather_data
                             self.last_weather_update = current_time
                             self.last_display_update = datetime.now()
-                        elif not valid_bus_data and not error_message and weather_enabled and weather_data:
+                        elif (
+                            not valid_bus_data
+                            and not error_message
+                            and weather_enabled
+                            and weather_data
+                            and not privacy.blocks("weather")
+                        ):
                             logger.info("No bus data available, switching to weather mode...")
                             if not self.in_weather_mode:
                                 # We're switching to weather mode, set base image for partial updates
@@ -1302,7 +1349,11 @@ class DisplayManager:
                             self.last_weather_update = current_time
                             self.last_display_update = datetime.now()
                             logger.info("Weather display updated successfully")
-                        elif valid_bus_data and not error_message:
+                        elif (
+                            valid_bus_data
+                            and not error_message
+                            and not privacy.blocks("transit")
+                        ):
                             logger.info("Updating bus display...")
                             # Pass the full weather data object to update_display
                             if self.in_weather_mode:
@@ -1323,7 +1374,11 @@ class DisplayManager:
                             self.last_display_update = datetime.now()
                             self.update_count += 1
                             logger.info("Bus display updated successfully")
-                        elif weather_enabled and weather_data:
+                        elif (
+                            weather_enabled
+                            and weather_data
+                            and not privacy.blocks("weather")
+                        ):
                             logger.info("Updating weather display...")
                             if not self.in_weather_mode:
                                 # We're switching to weather mode, set base image for partial updates

--- a/basic.py
+++ b/basic.py
@@ -49,6 +49,7 @@ from token_usage import (
     configured_token_views,
     token_view_at,
 )
+from vacation_privacy import VacationPrivacyMode
 from screen_arbiter import ScreenArbiter
 from rss_plugin import RSSPlugin
 from breaking_news_plugin import BreakingNewsPlugin
@@ -369,7 +370,8 @@ class DisplayManager:
         self.iss_screen_priority = int(
             os.getenv("screen_priority_iss", default_iss_priority)
         )
-        self.screen_arbiter = ScreenArbiter()
+        self.vacation_privacy = VacationPrivacyMode.from_env()
+        self.screen_arbiter = ScreenArbiter(blocked=self.vacation_privacy.blocks)
         self.override_priority = int(os.getenv("display_override_priority", "30"))
         self.override_duration_seconds = max(
             1, int(os.getenv("display_override_duration_seconds", "300"))
@@ -458,8 +460,14 @@ class DisplayManager:
             self._last_screen_owner = None
             self._force_display_update()
 
+    def _vacation_privacy(self):
+        return getattr(self, "vacation_privacy", VacationPrivacyMode())
+
     def _scheduled_mode(self, current_time):
         scheduled_mode = self.display_schedule.mode_at(current_time)
+        privacy = self._vacation_privacy()
+        if privacy.blocks(scheduled_mode, current_time):
+            return privacy.safe_fallback(current_time)
         if scheduled_mode in {"ynab", "ynab-always"}:
             if not self.ynab_client.enabled:
                 return self._ynab_fallback_mode()
@@ -480,6 +488,31 @@ class DisplayManager:
         ):
             return scheduled_mode
         return self._token_fallback_mode()
+
+    def _enforce_vacation_privacy(self, current_time):
+        privacy = self._vacation_privacy()
+        if not privacy.is_active(current_time):
+            return False
+        override_blocked = False
+        with self._override_lock:
+            if self._override_module and privacy.blocks(
+                self._override_module, current_time
+            ):
+                self._override_generation += 1
+                self._override_module = None
+                override_blocked = self.screen_arbiter.release(
+                    self.OVERRIDE_SCREEN_OWNER
+                )
+        # active_owner() also prunes plugin claims that became sensitive when
+        # a blackout date started.
+        self.screen_arbiter.active_owner()
+        current_blocked = privacy.blocks(
+            self.current_display_mode or "", current_time
+        )
+        if override_blocked or current_blocked:
+            self._last_screen_owner = None
+            return True
+        return False
 
     @staticmethod
     def _is_token_mode(mode):
@@ -607,6 +640,12 @@ class DisplayManager:
                 "error": "unknown module",
                 "modules": sorted(aliases),
             }
+        if self._vacation_privacy().blocks(normalized):
+            return {
+                "accepted": False,
+                "error": "module hidden by vacation privacy mode",
+                "module": normalized,
+            }
         with self._override_lock:
             self._override_generation += 1
             generation = self._override_generation
@@ -674,6 +713,7 @@ class DisplayManager:
             "active_owner": self.screen_arbiter.active_owner(),
             "duration_seconds": self.override_duration_seconds,
             "modules": sorted(set(self._override_aliases().values())),
+            "vacation_privacy_active": self._vacation_privacy().is_active(),
         }
 
     def _render_display_override(self, module=None, generation=None):
@@ -699,7 +739,11 @@ class DisplayManager:
             )
 
     def _render_display_override_locked(self, module, generation):
-        if not module or not self.screen_arbiter.can_render(self.OVERRIDE_SCREEN_OWNER):
+        if (
+            not module
+            or self._vacation_privacy().blocks(module)
+            or not self.screen_arbiter.can_render(self.OVERRIDE_SCREEN_OWNER)
+        ):
             return False
         handlers = getattr(self, "_display_override_handlers", None)
         if handlers is None:
@@ -1155,6 +1199,10 @@ class DisplayManager:
                             last_flight_log = 0
                             self.screen_arbiter.release(self.FLIGHT_SCREEN_OWNER)
                             logger.info(f"Starting flight cooldown period of {self.flight_mode_cooldown} seconds")
+
+                if self._enforce_vacation_privacy(current_time):
+                    self._force_display_update()
+                    self._schedule_next_update()
 
                 active_owner = self.screen_arbiter.active_owner()
                 if (

--- a/docs/setup/js/advanced_setup.js
+++ b/docs/setup/js/advanced_setup.js
@@ -3,6 +3,43 @@
 let currentSettings = {};
 
 const SETTING_GROUPS = {
+    vacationPrivacy: {
+        title: "Vacation Privacy",
+        description: "Hide selected display modules while you are away",
+        settings: {
+            vacation_mode_enabled: {
+                type: "boolean",
+                label: "Enable Vacation Privacy",
+                description: "Apply privacy mode during the configured blackout dates. With no dates, enabling this acts as a manual always-on privacy switch.",
+                default: false
+            },
+            vacation_mode_sensitive_displays: {
+                type: "text",
+                label: "Sensitive Displays",
+                description: "Comma-separated display families or patterns to hide, for example: calendar,token,ynab or calendar*,ha:*.",
+                default: "calendar,token,ynab"
+            },
+            vacation_mode_blackout_dates: {
+                type: "text",
+                label: "Blackout Dates",
+                description: "Inclusive date ranges separated by commas, for example: 2026-08-11..2026-08-14,2026-09-11..2026-09-26.",
+                default: ""
+            },
+            vacation_mode_timezone: {
+                type: "text",
+                label: "Privacy Timezone",
+                description: "IANA timezone used to decide when blackout dates begin and end.",
+                default: "UTC"
+            },
+            vacation_mode_fallback_mode: {
+                type: "select",
+                label: "Safe Fallback Display",
+                description: "Display mode used when a scheduled sensitive display is hidden.",
+                options: ["transit", "weather", "auto"],
+                default: "transit"
+            }
+        }
+    },
     flight: {
         title: "Flight Tracking Settings",
         description: "Configure how the device monitors nearby aircraft",
@@ -444,4 +481,4 @@ window.saveAdvancedSettings = async function (event) {
         console.error('Failed to save settings:', error);
         window.showError('Failed to save settings: ' + error.message);
     }
-} 
+}

--- a/docs/vacation-privacy-mode.md
+++ b/docs/vacation-privacy-mode.md
@@ -35,3 +35,5 @@ When privacy mode is active:
 Invalid blackout dates or timezone names fail closed: selected sensitive
 displays remain hidden until the configuration is corrected. Invalid or
 sensitive fallback selections automatically move to a safe built-in display.
+If `auto`, `transit`, and `weather` are all sensitive, the renderer retains the
+last safe frame instead of drawing a blocked fallback.

--- a/docs/vacation-privacy-mode.md
+++ b/docs/vacation-privacy-mode.md
@@ -1,0 +1,37 @@
+# Vacation privacy mode
+
+Vacation privacy mode prevents selected display modules from appearing while
+the device is visible to guests, house sitters, or other visitors. It applies
+the same policy to scheduled base views, plugin claims, and private-network
+display overrides.
+
+Configure it in Advanced Settings or in `.env`:
+
+```dotenv
+vacation_mode_enabled=true
+vacation_mode_sensitive_displays=calendar,token,ynab
+vacation_mode_blackout_dates=2026-08-11..2026-08-14,2026-09-11..2026-09-26
+vacation_mode_timezone=Europe/Brussels
+vacation_mode_fallback_mode=transit
+```
+
+Date ranges are inclusive in the configured IANA timezone. A single date is
+also valid. If blackout dates are blank, the enabled switch becomes a manual
+always-on privacy mode.
+
+Sensitive display names are comma-separated. A family name matches the family
+and its `-`, `_`, or `:` variants, so `calendar` also suppresses
+`calendar-event` and `calendar-agenda`. Shell-style patterns are supported for
+broader plugin families, for example `ha:*`.
+
+When privacy mode is active:
+
+- sensitive scheduled views use the configured safe fallback;
+- sensitive plugin claims are rejected, including claims that were already
+  active when a blackout date began;
+- sensitive display API overrides return a conflict instead of rendering;
+- non-sensitive displays continue to rotate normally.
+
+Invalid blackout dates or timezone names fail closed: selected sensitive
+displays remain hidden until the configuration is corrected. Invalid or
+sensitive fallback selections automatically move to a safe built-in display.

--- a/readme.md
+++ b/readme.md
@@ -15,6 +15,7 @@ A Raspberry Pi project that displays bus waiting times using an e-Paper display 
 - 📰 Optional RSS/Nitter plugin with compact new-entry notifications
 - 🏠 Optional generic Home Assistant cards and event takeovers
 - 🎛️ Screen arbitration, weekday-aware schedules, and a private-network display override API
+- 🔒 Vacation privacy mode for hiding configurable sensitive displays on selected dates
 
 [View detailed features and screenshots →](https://bdamokos.github.io/rpi_waiting_time_display/features/)
 
@@ -23,6 +24,10 @@ A Raspberry Pi project that displays bus waiting times using an e-Paper display 
 The calendar, YNAB glance, and RSS plugins share the screen safely with
 transit, weather, flight, ISS, and Codex views through the screen arbiter. Each
 plugin is disabled by default and configured in the untracked `.env` file.
+
+Vacation privacy mode can suppress selected display families across schedules,
+plugins, and display overrides while you are away. Configure it in Advanced
+Settings or see the [vacation privacy guide](docs/vacation-privacy-mode.md).
 
 See the [Home Assistant setup](docs/home-assistant-display.md) and
 [plugin authoring guide](docs/plugin-authoring.md).

--- a/screen_arbiter.py
+++ b/screen_arbiter.py
@@ -30,8 +30,13 @@ class ScreenClaim:
 class ScreenArbiter:
     """Choose which optional display plugin currently owns the screen."""
 
-    def __init__(self, clock: Callable[[], float] = time.monotonic):
+    def __init__(
+        self,
+        clock: Callable[[], float] = time.monotonic,
+        blocked: Optional[Callable[[str], bool]] = None,
+    ):
         self._clock = clock
+        self._blocked = blocked
         self._claims: Dict[str, ScreenClaim] = {}
         self._current_owner: Optional[str] = None
         self._sequence = 0
@@ -54,7 +59,16 @@ class ScreenArbiter:
             raise ValueError("screen claim ttl_seconds must be positive")
 
         with self._lock:
+            previous = self._current_owner
             self._prune_expired()
+            self._prune_blocked()
+            if self._is_blocked(owner):
+                self._claims.pop(owner, None)
+                if self._current_owner == owner:
+                    self._current_owner = None
+                self._select_owner()
+                self._log_transition(previous)
+                return False
             existing = self._claims.get(owner)
             if existing:
                 sequence = existing.sequence
@@ -68,7 +82,6 @@ class ScreenArbiter:
                 exclusive=exclusive,
                 sequence=sequence,
             )
-            previous = self._current_owner
             self._select_owner()
             self._log_transition(previous)
             return self._current_owner == owner
@@ -78,6 +91,7 @@ class ScreenArbiter:
 
         with self._lock:
             self._prune_expired()
+            self._prune_blocked()
             was_active = self._current_owner == owner
             previous = self._current_owner
             self._claims.pop(owner, None)
@@ -93,6 +107,7 @@ class ScreenArbiter:
         with self._lock:
             previous = self._current_owner
             self._prune_expired()
+            self._prune_blocked()
             self._select_owner()
             self._log_transition(previous)
             return self._current_owner
@@ -105,12 +120,24 @@ class ScreenArbiter:
     def has_claim(self, owner: str) -> bool:
         with self._lock:
             self._prune_expired()
+            self._prune_blocked()
             return owner in self._claims
 
     def claim_for(self, owner: str) -> Optional[ScreenClaim]:
         with self._lock:
             self._prune_expired()
+            self._prune_blocked()
             return self._claims.get(owner)
+
+    def _is_blocked(self, owner: str) -> bool:
+        return bool(self._blocked and self._blocked(owner))
+
+    def _prune_blocked(self) -> None:
+        blocked = [owner for owner in self._claims if self._is_blocked(owner)]
+        for owner in blocked:
+            self._claims.pop(owner, None)
+            if self._current_owner == owner:
+                self._current_owner = None
 
     def _prune_expired(self) -> None:
         now = self._clock()

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,7 @@ exec((Path(__file__).with_name("version.py")).read_text(), version_namespace)
 setup(
     name="weather",
     version=version_namespace["__version__"],
+    python_requires=">=3.9",
     packages=find_packages(),
     py_modules=[
         "dithering",

--- a/tests/test_screen_arbiter.py
+++ b/tests/test_screen_arbiter.py
@@ -102,3 +102,15 @@ def test_claim_rejects_empty_owner(owner):
 def test_claim_rejects_non_positive_ttl():
     with pytest.raises(ValueError):
         ScreenArbiter().claim("flight", 1, 0)
+
+
+def test_blocked_owner_cannot_claim_and_existing_claim_is_pruned():
+    blocked = set()
+    arbiter = ScreenArbiter(blocked=lambda owner: owner in blocked)
+    assert arbiter.claim("calendar-agenda", 20, 60)
+
+    blocked.add("calendar-agenda")
+
+    assert arbiter.active_owner() is None
+    assert not arbiter.has_claim("calendar-agenda")
+    assert not arbiter.claim("calendar-agenda", 20, 60)

--- a/tests/test_vacation_privacy.py
+++ b/tests/test_vacation_privacy.py
@@ -1,0 +1,66 @@
+from datetime import date, datetime
+from zoneinfo import ZoneInfo
+
+from vacation_privacy import DateWindow, VacationPrivacyMode
+
+
+def test_disabled_policy_never_blocks():
+    policy = VacationPrivacyMode(
+        enabled=False,
+        sensitive_displays=("calendar",),
+        timezone="Europe/Brussels",
+    )
+
+    assert not policy.blocks("calendar-agenda", datetime(2026, 8, 12))
+
+
+def test_manual_mode_without_dates_is_always_active():
+    policy = VacationPrivacyMode(
+        enabled=True,
+        sensitive_displays=("calendar", "token*"),
+        timezone="Europe/Brussels",
+    )
+
+    assert policy.blocks("calendar-event", datetime(2026, 8, 12))
+    assert policy.blocks("token-always", datetime(2026, 8, 12))
+    assert not policy.blocks("weather", datetime(2026, 8, 12))
+
+
+def test_date_windows_are_inclusive_in_configured_timezone():
+    policy = VacationPrivacyMode(
+        enabled=True,
+        sensitive_displays=("ynab",),
+        windows=(DateWindow(date(2026, 8, 11), date(2026, 8, 14)),),
+        timezone="Europe/Brussels",
+    )
+
+    assert policy.blocks(
+        "ynab-glance",
+        datetime(2026, 8, 10, 22, 30, tzinfo=ZoneInfo("UTC")),
+    )
+    assert not policy.blocks(
+        "ynab-glance",
+        datetime(2026, 8, 14, 22, 30, tzinfo=ZoneInfo("UTC")),
+    )
+
+
+def test_invalid_environment_fails_closed(monkeypatch):
+    monkeypatch.setenv("vacation_mode_enabled", "true")
+    monkeypatch.setenv("vacation_mode_sensitive_displays", "calendar,ynab,token")
+    monkeypatch.setenv("vacation_mode_blackout_dates", "not-a-date")
+
+    policy = VacationPrivacyMode.from_env()
+
+    assert policy.fail_closed
+    assert policy.blocks("calendar-agenda")
+
+
+def test_safe_fallback_skips_sensitive_configured_mode():
+    policy = VacationPrivacyMode(
+        enabled=True,
+        sensitive_displays=("transit",),
+        timezone="UTC",
+        fallback_mode="transit",
+    )
+
+    assert policy.safe_fallback() == "weather"

--- a/tests/test_vacation_privacy.py
+++ b/tests/test_vacation_privacy.py
@@ -1,6 +1,8 @@
 from datetime import date, datetime
 from zoneinfo import ZoneInfo
 
+import pytest
+
 from vacation_privacy import DateWindow, VacationPrivacyMode
 
 
@@ -11,7 +13,9 @@ def test_disabled_policy_never_blocks():
         timezone="Europe/Brussels",
     )
 
-    assert not policy.blocks("calendar-agenda", datetime(2026, 8, 12))
+    assert not policy.blocks(
+        "calendar-agenda", datetime(2026, 8, 12, tzinfo=ZoneInfo("UTC"))
+    )
 
 
 def test_manual_mode_without_dates_is_always_active():
@@ -21,9 +25,10 @@ def test_manual_mode_without_dates_is_always_active():
         timezone="Europe/Brussels",
     )
 
-    assert policy.blocks("calendar-event", datetime(2026, 8, 12))
-    assert policy.blocks("token-always", datetime(2026, 8, 12))
-    assert not policy.blocks("weather", datetime(2026, 8, 12))
+    now = datetime(2026, 8, 12, tzinfo=ZoneInfo("UTC"))
+    assert policy.blocks("calendar-event", now)
+    assert policy.blocks("token-always", now)
+    assert not policy.blocks("weather", now)
 
 
 def test_date_windows_are_inclusive_in_configured_timezone():
@@ -64,3 +69,38 @@ def test_safe_fallback_skips_sensitive_configured_mode():
     )
 
     assert policy.safe_fallback() == "weather"
+
+
+def test_timezone_boundary_converts_aware_device_timestamp():
+    policy = VacationPrivacyMode(
+        enabled=True,
+        sensitive_displays=("calendar",),
+        windows=(DateWindow(date(2026, 8, 11), date(2026, 8, 11)),),
+        timezone="Pacific/Kiritimati",
+    )
+
+    assert policy.blocks(
+        "calendar-agenda",
+        datetime(2026, 8, 10, 11, 30, tzinfo=ZoneInfo("America/Los_Angeles")),
+    )
+
+
+def test_naive_timestamp_is_rejected():
+    policy = VacationPrivacyMode(
+        enabled=True,
+        windows=(DateWindow(date(2026, 8, 11), date(2026, 8, 11)),),
+        timezone="UTC",
+    )
+
+    with pytest.raises(ValueError, match="timezone-aware"):
+        policy.is_active(datetime(2026, 8, 11))
+
+
+def test_safe_fallback_returns_none_when_all_builtins_are_sensitive():
+    policy = VacationPrivacyMode(
+        enabled=True,
+        sensitive_displays=("auto", "transit", "weather"),
+        timezone="UTC",
+    )
+
+    assert policy.safe_fallback() is None

--- a/tests/test_vacation_privacy_integration.py
+++ b/tests/test_vacation_privacy_integration.py
@@ -1,0 +1,59 @@
+import threading
+from datetime import datetime
+
+from basic import DisplayManager
+from screen_arbiter import ScreenArbiter
+from vacation_privacy import VacationPrivacyMode
+
+
+class FixedSchedule:
+    def __init__(self, mode):
+        self.mode = mode
+
+    def mode_at(self, _now):
+        return self.mode
+
+
+def _active_policy(*names):
+    return VacationPrivacyMode(
+        enabled=True,
+        sensitive_displays=names,
+        timezone="Europe/Brussels",
+        fallback_mode="transit",
+    )
+
+
+def test_sensitive_scheduled_mode_uses_safe_fallback():
+    manager = DisplayManager.__new__(DisplayManager)
+    manager.display_schedule = FixedSchedule("token-always")
+    manager.vacation_privacy = _active_policy("token")
+
+    assert manager._scheduled_mode(datetime(2026, 8, 12)) == "transit"
+
+
+def test_sensitive_override_is_rejected_before_claiming_screen():
+    manager = DisplayManager.__new__(DisplayManager)
+    manager.screen_arbiter = ScreenArbiter()
+    manager.vacation_privacy = _active_policy("calendar")
+
+    result = manager.request_display_override("calendar")
+
+    assert not result["accepted"]
+    assert result["error"] == "module hidden by vacation privacy mode"
+    assert manager.screen_arbiter.active_owner() is None
+
+
+def test_active_sensitive_override_is_released_at_blackout_boundary():
+    manager = DisplayManager.__new__(DisplayManager)
+    manager.screen_arbiter = ScreenArbiter()
+    manager.vacation_privacy = _active_policy("calendar")
+    manager._override_lock = threading.RLock()
+    manager._override_module = "calendar"
+    manager._override_generation = 1
+    manager._last_screen_owner = manager.OVERRIDE_SCREEN_OWNER
+    manager.current_display_mode = "calendar-agenda"
+    manager.screen_arbiter.claim(manager.OVERRIDE_SCREEN_OWNER, 30, 300)
+
+    assert manager._enforce_vacation_privacy(datetime(2026, 8, 12))
+    assert manager._override_module is None
+    assert manager.screen_arbiter.active_owner() is None

--- a/tests/test_vacation_privacy_integration.py
+++ b/tests/test_vacation_privacy_integration.py
@@ -54,6 +54,25 @@ def test_active_sensitive_override_is_released_at_blackout_boundary():
     manager.current_display_mode = "calendar-agenda"
     manager.screen_arbiter.claim(manager.OVERRIDE_SCREEN_OWNER, 30, 300)
 
-    assert manager._enforce_vacation_privacy(datetime(2026, 8, 12))
+    assert manager._enforce_vacation_privacy()
     assert manager._override_module is None
     assert manager.screen_arbiter.active_owner() is None
+
+
+def test_scheduled_sensitive_mode_has_no_fallback_when_all_builtins_blocked():
+    manager = DisplayManager.__new__(DisplayManager)
+    manager.display_schedule = FixedSchedule("token-always")
+    manager.vacation_privacy = _active_policy(
+        "token", "auto", "transit", "weather"
+    )
+
+    assert manager._scheduled_mode(datetime(2026, 8, 12)) is None
+
+
+def test_data_fallback_is_rechecked_against_privacy_policy():
+    manager = DisplayManager.__new__(DisplayManager)
+    manager.vacation_privacy = _active_policy(
+        "auto", "transit", "weather"
+    )
+
+    assert manager._privacy_safe_mode("weather") is None

--- a/vacation_privacy.py
+++ b/vacation_privacy.py
@@ -1,0 +1,141 @@
+"""Date-bounded privacy policy for suppressing configured display modules."""
+
+from __future__ import annotations
+
+import fnmatch
+import logging
+import os
+from dataclasses import dataclass
+from datetime import date, datetime
+from typing import Iterable, Optional, Tuple
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+logger = logging.getLogger(__name__)
+
+
+def _enabled(value: str) -> bool:
+    return value.strip().lower() in {"1", "true", "yes", "on"}
+
+
+@dataclass(frozen=True)
+class DateWindow:
+    start: date
+    end: date
+
+    def contains(self, value: date) -> bool:
+        return self.start <= value <= self.end
+
+
+def _parse_windows(value: str) -> Tuple[DateWindow, ...]:
+    windows = []
+    for raw_entry in value.split(","):
+        entry = raw_entry.strip()
+        if not entry:
+            continue
+        if ".." in entry:
+            raw_start, raw_end = entry.split("..", 1)
+        else:
+            raw_start = raw_end = entry
+        start = date.fromisoformat(raw_start.strip())
+        end = date.fromisoformat(raw_end.strip())
+        if end < start:
+            raise ValueError(f"vacation date range ends before it starts: {entry}")
+        windows.append(DateWindow(start, end))
+    return tuple(windows)
+
+
+class VacationPrivacyMode:
+    """Suppress sensitive display names during configured local-date windows.
+
+    Empty blackout dates mean that the enabled switch is a manual always-on
+    privacy mode. Invalid dates or timezone names fail closed by activating the
+    policy continuously, while still allowing non-sensitive displays to run.
+    """
+
+    def __init__(
+        self,
+        *,
+        enabled: bool = False,
+        sensitive_displays: Iterable[str] = (),
+        windows: Iterable[DateWindow] = (),
+        timezone: str = "UTC",
+        fallback_mode: str = "transit",
+        fail_closed: bool = False,
+    ):
+        self.enabled = bool(enabled)
+        self.sensitive_displays = tuple(
+            item.strip().lower() for item in sensitive_displays if item.strip()
+        )
+        self.windows = tuple(windows)
+        self.fail_closed = bool(fail_closed)
+        self.timezone_name = timezone
+        self.timezone = ZoneInfo(timezone)
+        self.fallback_mode = fallback_mode.strip().lower()
+
+    @classmethod
+    def from_env(cls) -> "VacationPrivacyMode":
+        enabled = _enabled(os.getenv("vacation_mode_enabled", "false"))
+        displays = os.getenv("vacation_mode_sensitive_displays", "").split(",")
+        timezone = os.getenv("vacation_mode_timezone", "UTC").strip() or "UTC"
+        fallback = os.getenv("vacation_mode_fallback_mode", "transit")
+        try:
+            windows = _parse_windows(os.getenv("vacation_mode_blackout_dates", ""))
+            return cls(
+                enabled=enabled,
+                sensitive_displays=displays,
+                windows=windows,
+                timezone=timezone,
+                fallback_mode=fallback,
+            )
+        except (ValueError, ZoneInfoNotFoundError) as exc:
+            logger.error(
+                "Invalid vacation privacy configuration; sensitive displays "
+                "will remain suppressed until corrected: %s",
+                exc,
+            )
+            return cls(
+                enabled=enabled,
+                sensitive_displays=displays,
+                timezone="UTC",
+                fallback_mode=fallback,
+                fail_closed=enabled,
+            )
+
+    def is_active(self, now: Optional[datetime] = None) -> bool:
+        if not self.enabled:
+            return False
+        if self.fail_closed or not self.windows:
+            return True
+        if now is None:
+            local_date = datetime.now(self.timezone).date()
+        elif now.tzinfo is None:
+            local_date = now.date()
+        else:
+            local_date = now.astimezone(self.timezone).date()
+        return any(window.contains(local_date) for window in self.windows)
+
+    def blocks(self, display_name: str, now: Optional[datetime] = None) -> bool:
+        if not self.is_active(now):
+            return False
+        name = (display_name or "").strip().lower()
+        if not name:
+            return False
+        return any(self._matches(pattern, name) for pattern in self.sensitive_displays)
+
+    @staticmethod
+    def _matches(pattern: str, name: str) -> bool:
+        if any(character in pattern for character in "*?["):
+            return fnmatch.fnmatchcase(name, pattern)
+        return name == pattern or name.startswith(
+            (f"{pattern}-", f"{pattern}_", f"{pattern}:")
+        )
+
+    def safe_fallback(self, now: Optional[datetime] = None) -> str:
+        configured = self.fallback_mode
+        candidates = [configured, "transit", "weather", "auto"]
+        for candidate in candidates:
+            if candidate in {"auto", "transit", "weather"} and not self.blocks(
+                candidate, now
+            ):
+                return candidate
+        return "auto"

--- a/vacation_privacy.py
+++ b/vacation_privacy.py
@@ -6,7 +6,7 @@ import fnmatch
 import logging
 import os
 from dataclasses import dataclass
-from datetime import date, datetime
+from datetime import date, datetime, timezone
 from typing import Iterable, Optional, Tuple
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
@@ -106,12 +106,10 @@ class VacationPrivacyMode:
             return False
         if self.fail_closed or not self.windows:
             return True
-        if now is None:
-            local_date = datetime.now(self.timezone).date()
-        elif now.tzinfo is None:
-            local_date = now.date()
-        else:
-            local_date = now.astimezone(self.timezone).date()
+        moment = now if now is not None else datetime.now(timezone.utc)
+        if moment.tzinfo is None:
+            raise ValueError("vacation privacy timestamps must be timezone-aware")
+        local_date = moment.astimezone(self.timezone).date()
         return any(window.contains(local_date) for window in self.windows)
 
     def blocks(self, display_name: str, now: Optional[datetime] = None) -> bool:
@@ -130,7 +128,7 @@ class VacationPrivacyMode:
             (f"{pattern}-", f"{pattern}_", f"{pattern}:")
         )
 
-    def safe_fallback(self, now: Optional[datetime] = None) -> str:
+    def safe_fallback(self, now: Optional[datetime] = None) -> Optional[str]:
         configured = self.fallback_mode
         candidates = [configured, "transit", "weather", "auto"]
         for candidate in candidates:
@@ -138,4 +136,4 @@ class VacationPrivacyMode:
                 candidate, now
             ):
                 return candidate
-        return "auto"
+        return None


### PR DESCRIPTION
## Summary
- add date-bounded vacation privacy settings with configurable sensitive display families
- enforce suppression across scheduled views, plugin arbitration, and display overrides
- fail closed on invalid date/timezone configuration and document manual always-on mode

## Validation
- 448 tests passed in the sandboxed full suite
- Unix systemd notification socket test passed separately outside the macOS sandbox
- focused vacation/privacy integration suite: 79 passed
- JavaScript syntax and diff checks passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added vacation privacy mode to hide configured sensitive displays during selected blackout dates.
  * Added support for timezone-aware date ranges, display-name patterns, manual activation, and safe fallback displays.
  * Privacy mode now suppresses sensitive scheduled views, overrides, and active display claims.

* **Documentation**
  * Added setup guidance and configuration details for vacation privacy mode.

* **Bug Fixes**
  * Invalid dates or timezones now fail safely by hiding sensitive displays and using a secure fallback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->